### PR TITLE
Include array STL header

### DIFF
--- a/tests/googletest/test-fragmentUtils.cpp
+++ b/tests/googletest/test-fragmentUtils.cpp
@@ -10,6 +10,7 @@
 #include <fragmentIterators/StoredFragments.h>
 #include <fragmentUtils/InsertionIterator.h>
 #include <arrayIO/vector.h>
+#include <array>
 
 using namespace BPCells;
 


### PR DESCRIPTION
Without this header the file wouldn't compile on macOS 12.6