### PR TITLE
respect `matrix_type` when coerced into matrix

### DIFF
--- a/R/matrix.R
+++ b/R/matrix.R
@@ -2385,8 +2385,26 @@ setAs("IterableMatrix", "matrix", function(from) {
   rlang::inform(c(
       "Warning: Converting to a dense matrix may use excessive memory"
     ), .frequency = "regularly", .frequency_id = "matrix_dense_conversion")
-  as(from, "dgCMatrix") %>% as.matrix()  
+  # `mat` will always be numeric mode
+  mat <- as.matrix(as(from, "dgCMatrix"))
+  # to keep the original mode, we transform it when necessary
+  if (matrix_type(from) == "uint32_t") {
+      mat <- matrix_to_integer(mat)
+  }
+  mat
 })
+
+matrix_to_integer <- function(matrix) { # a numeric matrix
+    if (is.integer(matrix)) return(matrix) # styler: off
+    if (all(matrix <= .Machine$integer.max)) {
+        storage.mode(matrix) <- "integer"
+    } else {
+        cli::cli_warn(
+            "Using `double` mode since some values exceed {.code .Machine$integer.max}"
+        )
+    }
+    matrix
+}
 
 #' @exportS3Method base::as.matrix
 as.matrix.IterableMatrix <- function(x, ...) as(x, "matrix")

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -2399,9 +2399,9 @@ matrix_to_integer <- function(matrix) { # a numeric matrix
     if (all(matrix <= .Machine$integer.max)) {
         storage.mode(matrix) <- "integer"
     } else {
-        cli::cli_warn(
-            "Using `double` mode since some values exceed {.code .Machine$integer.max}"
-        )
+      warning(
+        "Using `double` mode since some values exceed `.Machine$integer.max`"
+      )
     }
     matrix
 }

--- a/tests/testthat/test-matrix_transforms.R
+++ b/tests/testthat/test-matrix_transforms.R
@@ -109,19 +109,19 @@ test_that("binarize works", {
     m2 <- as(as(m, 'dgCMatrix'), 'IterableMatrix')
 
     m3 <- as(binarize(m2), 'matrix')
-    ans3 <- matrix(c(0, 1, 0, 1, 1, 1, 1, 1), nrow=2)
+    ans3 <- matrix(as.integer(c(0, 1, 0, 1, 1, 1, 1, 1)), nrow=2)
     expect_identical(m3, ans3)
     expect_identical(as(m2 > 0L, 'matrix'), ans3)
     expect_identical(as(0L < m2, 'matrix'), ans3)
 
     m4 <- as(binarize(m2, threshold=.5), 'matrix')
-    ans4 <- matrix(c(0, 0, 0, 1, 0, 1, 0, 1), nrow=2)
+    ans4 <- matrix(as.integer(c(0, 0, 0, 1, 0, 1, 0, 1)), nrow=2)
     expect_identical(m4, ans4)
     expect_identical(as(m2 > 0.5, 'matrix'), ans4)
     expect_identical(as(0.5 < m2, 'matrix'), ans4)
 
     m5 <- as(binarize(m2, threshold=.5, strict_inequality=FALSE), 'matrix')
-    ans5 <- matrix(c(0, 1, 0, 1, 0, 1, 0, 1), nrow=2)
+    ans5 <- matrix(as.integer(c(0, 1, 0, 1, 0, 1, 0, 1)), nrow=2)
     expect_identical(m5, ans5)
     expect_identical(as(m2 >= 0.5, 'matrix'), ans5)
     expect_identical(as(0.5 <= m2, 'matrix'), ans5)

--- a/tests/testthat/test-matrix_utils.R
+++ b/tests/testthat/test-matrix_utils.R
@@ -33,6 +33,29 @@ test_that("Conversion to base types works", {
   }
 })
 
+test_that("Conversion to dense matrix keep data types", {
+  m_double <- as(generate_sparse_matrix(10, 10), "IterableMatrix")
+  # convert to double matrix
+  expect_identical(matrix_type(m_double), "double")
+  expect_identical(storage.mode(as.matrix(m_double)), "double")
+  # convert to double matrix
+  m_float <- convert_matrix_type(m_double, "float")
+  expect_identical(matrix_type(m_float), "float")
+  expect_identical(storage.mode(as.matrix(m_float)), "double")
+  # convert to integer matrix
+  m_integer <- convert_matrix_type(m_double, "uint32_t")
+  expect_identical(matrix_type(m_integer), "uint32_t")
+  expect_identical(storage.mode(as.matrix(m_integer)), "integer")
+  # value exceed `.Machine$integer.max` return double mode and warn message
+  m_large <- generate_dense_matrix(10, 10)
+  m_large[1L] <- m_large[1L] + .Machine$integer.max
+  m_large <- as(as(m_large, "dgCMatrix"), "IterableMatrix")
+  m_large_integer <- convert_matrix_type(m_large, "uint32_t")
+  expect_identical(matrix_type(m_large_integer), "uint32_t")
+  expect_warning(dense_mat <- as.matrix(m_large_integer))
+  expect_identical(storage.mode(dense_mat), "double")
+})
+
 test_that("Chained subsetting works", {
   m1 <- generate_dense_matrix(10, 10) %>% as("dgCMatrix")
 

--- a/tests/testthat/test-matrix_utils.R
+++ b/tests/testthat/test-matrix_utils.R
@@ -34,26 +34,28 @@ test_that("Conversion to base types works", {
 })
 
 test_that("Conversion to dense matrix keep data types", {
-  m_double <- as(generate_sparse_matrix(10, 10), "IterableMatrix")
+  m <- generate_sparse_matrix(10, 10)
+  m_double <- as(m, "IterableMatrix")
   # convert to double matrix
   expect_identical(matrix_type(m_double), "double")
-  expect_identical(storage.mode(as.matrix(m_double)), "double")
+  expect_identical(as.matrix(m_double), as.matrix(m))
   # convert to double matrix
   m_float <- convert_matrix_type(m_double, "float")
   expect_identical(matrix_type(m_float), "float")
-  expect_identical(storage.mode(as.matrix(m_float)), "double")
+  expect_identical(as.matrix(m_float), as.matrix(m))
   # convert to integer matrix
   m_integer <- convert_matrix_type(m_double, "uint32_t")
   expect_identical(matrix_type(m_integer), "uint32_t")
-  expect_identical(storage.mode(as.matrix(m_integer)), "integer")
+  expect_identical(as.matrix(m_integer), matrix(as.integer(as.matrix(m)), nrow=nrow(m)))
   # value exceed `.Machine$integer.max` return double mode and warn message
   m_large <- generate_dense_matrix(10, 10)
   m_large[1L] <- m_large[1L] + .Machine$integer.max
-  m_large <- as(as(m_large, "dgCMatrix"), "IterableMatrix")
-  m_large_integer <- convert_matrix_type(m_large, "uint32_t")
+  m_large_integer <- as(m_large, "dgCMatrix") %>%
+    as("IterableMatrix") %>%
+    convert_matrix_type("uint32_t")
   expect_identical(matrix_type(m_large_integer), "uint32_t")
-  expect_warning(dense_mat <- as.matrix(m_large_integer))
-  expect_identical(storage.mode(dense_mat), "double")
+  expect_warning(dense_mat <- as.matrix(m_large_integer), "integer.max")
+  expect_identical(dense_mat, m_large)
 })
 
 test_that("Chained subsetting works", {


### PR DESCRIPTION
``` r
library(BPCells)
mock_matrix <- function(ngenes, ncells) {
    cell.means <- 2^stats::runif(ngenes, 2, 10)
    cell.disp <- 100 / cell.means + 0.5
    cell.data <- matrix(stats::rnbinom(ngenes * ncells,
        mu = cell.means,
        size = 1 / cell.disp
    ), ncol = ncells)
    rownames(cell.data) <- sprintf("Gene_%s", formatC(seq_len(ngenes),
        width = 4, flag = 0
    ))
    colnames(cell.data) <- sprintf("Cell_%s", formatC(seq_len(ncells),
        width = 3, flag = 0
    ))
    cell.data
}
tmpdir <- tempdir()
mat <- mock_matrix(30, 20)
path <- normalizePath(tempfile(tmpdir = tmpdir), mustWork = FALSE)
obj <- write_matrix_dir(mat = as(mat, "dgCMatrix"), dir = path)
#> Warning: Matrix compression performs poorly with non-integers.
#> • Consider calling convert_matrix_type if a compressed integer matrix is intended.
#> This message is displayed once every 8 hours.
storage.mode(as.matrix(obj))
#> Warning: Converting to a dense matrix may use excessive memory
#> This message is displayed once every 8 hours.
#> [1] "double"
obj <- convert_matrix_type(obj, "uint32_t")
storage.mode(as.matrix(obj))
#> [1] "integer"
```

<sup>Created on 2024-03-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
~                                                                                    
~                                                                                    
~                                                                                    
~                         