### PR TITLE
[r] Fix `trackplot_coverage()` when interacting with single clusters

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -23,9 +23,10 @@ Contributions welcome :)
 - `trackplot_loop()` now accepts discrete color scales
 
 ## Bug-fixes
-- Fixed error message when a matrix is too large to be converted to dgCMatrix (Thanks to @RookieA1 for reporting issue #95)
+- Fixed error message when a matrix is too large to be converted to dgCMatrix. (Thanks to @RookieA1 for reporting issue #95)
 - Fixed forgetting dimnames when subsetting after certain sets of
-  operations (Thanks to @Yunuuuu for reporting issues #97 and #100)
+  operations. (Thanks to @Yunuuuu for reporting issues #97 and #100)
+- Fixed plotting crashes when running `trackplot_coverage` with fragments from a single cluster. (Thanks to @sjessa for directly reporting this bug and coming up with a fix)
 
 # BPCells 0.2.0 (6/14/2024)
 

--- a/r/R/trackplots.R
+++ b/r/R/trackplots.R
@@ -389,7 +389,7 @@ trackplot_coverage <- function(fragments, region, groups,
     as("dgCMatrix") %>%
     as("matrix")
   # Discard any partial bins
-  mat <- mat[seq_along(bin_centers), ]
+  mat <- mat[seq_along(bin_centers), , drop = FALSE]
 
   data <- tibble::tibble(
     pos = rep(bin_centers, ncol(mat)),

--- a/r/tests/testthat/test-trackplots.R
+++ b/r/tests/testthat/test-trackplots.R
@@ -180,9 +180,10 @@ test_that("trackplot_coverage doesn't crash", {
       atac_reads = as.integer(seq(from=0, to=10, length.out=length(cell_names))),
       cell_type = sample(c("T", "B", "NK"), size = length(cell_names), replace=TRUE)
     )
-    region <- GenomicRanges::GRanges(
-        seqnames = S4Vectors::Rle(c("chr15")),
-        ranges = IRanges::IRanges(30000000:52806155)
+    region <- tibble::tibble(
+        chr = "chr15",
+        start = 30000000,
+        end = 52806155,
     )
     expect_no_condition(
         ggplot2::ggplot_build(trackplot_coverage(


### PR DESCRIPTION
# Description
Changes `trackplot_coverage()` so to prevent data conversion from tibble to named vector when dealing with only one cluster.

# Tests
- Added test cases for `trackplot_coverage()` to check for crashing out in both multi-cluster and single-cluster cases
- Added test for `trackplot_coverage()` return data type