### PR TITLE
[r] fix trackplot bugs with small tracks/motifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For MacOS, installing HDF5 through homebrew seems to be most reliable: `brew ins
 
 ### General Installation troubleshooting
 BPCells tries to print informative error messages during compilation to help diagnose the problem. For a more
-verbose set of information, run `Sys.setenv(BPCELLS_DEBUG_INSTALL="true")` prior to `remotes::install_github("bnprks/BPCells")`. If you still can't solve the issue with that additional information, feel free to file a Github issue, being
+verbose set of information, run `Sys.setenv(BPCELLS_DEBUG_INSTALL="true")` prior to `remotes::install_github("bnprks/BPCells/r")`. If you still can't solve the issue with that additional information, feel free to file a Github issue, being
 sure to use a [collapsible section](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) for the verbose installation log.
 
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -26,7 +26,8 @@ Contributions welcome :)
 - Fixed error message when a matrix is too large to be converted to dgCMatrix. (Thanks to @RookieA1 for reporting issue #95)
 - Fixed forgetting dimnames when subsetting after certain sets of
   operations. (Thanks to @Yunuuuu for reporting issues #97 and #100)
-- Fixed plotting crashes when running `trackplot_coverage` with fragments from a single cluster. (Thanks to @sjessa for directly reporting this bug and coming up with a fix)
+- Fixed plotting crashes when running `trackplot_coverage()` with fragments from a single cluster. (Thanks to @sjessa for directly reporting this bug and coming up with a fix)
+- Fixed issues with `trackplot_coverage()` when called with ranges less than 500 bp in length (Thanks to @bettybliu for directly reporting this bug.)
 
 # BPCells 0.2.0 (6/14/2024)
 

--- a/r/index.md
+++ b/r/index.md
@@ -63,7 +63,7 @@ For MacOS, installing HDF5 through homebrew seems to be most reliable: `brew ins
 
 ### General Installation troubleshooting
 BPCells tries to print informative error messages during compilation to help diagnose the problem. For a more
-verbose set of information, run `Sys.setenv(BPCELLS_DEBUG_INSTALL="true")` prior to `remotes::install_github("bnprks/BPCells")`. If you still can't solve the issue with that additional information, feel free to file a Github issue, being
+verbose set of information, run `Sys.setenv(BPCELLS_DEBUG_INSTALL="true")` prior to `remotes::install_github("bnprks/BPCells/r")`. If you still can't solve the issue with that additional information, feel free to file a Github issue, being
 sure to use a [collapsible section](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections) for the verbose installation log.
 
 

--- a/r/tests/testthat/test-trackplots.R
+++ b/r/tests/testthat/test-trackplots.R
@@ -212,7 +212,7 @@ test_that("trackplot_coverage doesn't crash", {
     frags_metadata <- tibble::tibble(
       id = cell_names,
       atac_reads = as.integer(seq(from=0, to=10, length.out=length(cell_names))),
-      cell_type = sample(c("T", "B", "NK"), size = length(cell_names), replace=TRUE)
+      cell_type = rep(c("NK", "B", "T"), ceiling(length(cell_names)/3))[1:length(cell_names)]
     )
     # general region
     region1 <- tibble::tibble(
@@ -223,8 +223,8 @@ test_that("trackplot_coverage doesn't crash", {
     # for small motifs
     region2 <- tibble::tibble(
         chr = "chr15",
-        start = 31283779,# 31277136,
-        end = 31283870#31322748
+        start = 31283779,
+        end = 31283870
     )
     frags_metadata_one_cluster <- frags_metadata[frags_metadata$cell_type == "T",]
     # checks for only one cluster

--- a/r/tests/testthat/test-trackplots.R
+++ b/r/tests/testthat/test-trackplots.R
@@ -91,12 +91,24 @@ test_that("creating continuous trackplot arrows works", {
         strand = c(rep(TRUE, 50), rep(FALSE, 50))
     )
     expect_identical(segs, segs_expected)
+
+    segs_expected_head_only <- tibble::tibble(
+        start = c(seq(10100, 15000, 100) - 1e-4, seq(10000, 14900, 100)),
+        end = c(seq(10100, 15000, 100), seq(10000, 14900, 100) + 1e-4),
+        strand = c(rep(TRUE, 50), rep(FALSE, 50))
+    )
+    expect_identical(
+        trackplot_create_arrow_segs(data1, region, 100, head_only=TRUE), 
+        segs_expected_head_only
+    )
+
     segs_with_metadata <- trackplot_create_arrow_segs(data2, region, 100)
     segs_expected_with_metadata <- segs_expected %>% 
         tibble::add_column(
             chr = c(rep("chr1", 100)),
             label = c(rep("A", 50), rep("C", 50)))
     expect_identical(segs_with_metadata, segs_expected_with_metadata)
+
     segs_small <- trackplot_create_arrow_segs(data3, region, 100)
     segs_expected_small <- tibble::tibble(
         start = c(10000, 10050),
@@ -104,6 +116,16 @@ test_that("creating continuous trackplot arrows works", {
         strand = c(TRUE, FALSE)
     )
     expect_identical(segs_small, segs_expected_small)
+
+    segs_expected_small_head_only <- tibble::tibble(
+        start = c(10010-1e-4, 10050),
+        end = c(10010, 10050+1e-4),
+        strand = c(TRUE, FALSE)
+    )
+    expect_identical(
+        trackplot_create_arrow_segs(data3, region, 100, head_only=TRUE),
+        segs_expected_small_head_only
+    )
 })
 
 test_that("trackplot_genome_annotation doesn't crash", {

--- a/r/vignettes/pbmc3k.Rmd
+++ b/r/vignettes/pbmc3k.Rmd
@@ -72,7 +72,7 @@ remotes::install_github(c("GreenleafLab/motifmatchr", "GreenleafLab/chromVARmoti
 <details>
   <summary>**Install BPCells**</summary>
 ```{r, eval=FALSE}
-remotes::install_github(c("bnprks/BPCells"))
+remotes::install_github(c("bnprks/BPCells/r"))
 ```
 
 </details>


### PR DESCRIPTION
# Description
Various small changes to coverage plots and genome peak plots to handle smaller motifs better.

- Created at least a single arrow for peaks that are not long enough for the pre-determined minimum arrow segment length.  Note, in very small peaks the arrow may go out of bounds of the peak itself, which will likely also need to be fixed in the future.
- Fixed an issue where the head_only boolean flow in `trackplot_create_arrow_segs()` did not properly assign values to the start and end position if a strand was negative.
- Fixed an issue arising from tracks smaller than 500 bp in `trackplot_coverage()`

# Tests
- Added a small test case for the head_only boolean flow in `trackplot_create_arrow_segs()`
- Added tests for small regions in `trackplot_coverage()`