### PR TITLE
[r] Fix Rcpp warning about out-of-bounds access

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -30,6 +30,7 @@ Contributions welcome :)
   operations. (Thanks to @Yunuuuu for reporting issues #97 and #100)
 - Fixed plotting crashes when running `trackplot_coverage()` with fragments from a single cluster. (Thanks to @sjessa for directly reporting this bug and coming up with a fix)
 - Fixed issues with `trackplot_coverage()` when called with ranges less than 500 bp in length (Thanks to @bettybliu for directly reporting this bug.)
+- Fix Rcpp warning created when handling compressed matrices with only one non-zero entry (pull request #123)
 
 ## Deprecations
 - `trackplot_coverage()` `legend_label` argument is now ignored, as the color legend is no longer shown by default for coverage plots.

--- a/r/src/R_array_io.cpp
+++ b/r/src/R_array_io.cpp
@@ -44,22 +44,24 @@ uint64_t RcppStringReader::size() { return data.size(); }
 S4ReaderBuilder::S4ReaderBuilder(S4 s4, uint32_t load_size) : s4(s4), load_size(load_size) {}
 UIntReader S4ReaderBuilder::openUIntReader(std::string name) {
     IntegerVector v = s4.slot(name);
-    return UIntReader(std::make_unique<VecUIntReader>((uint32_t *)&v[0], v.size()), load_size);
+    int32_t * data = v.begin();
+    return UIntReader(std::make_unique<VecUIntReader>((uint32_t *) data, v.size()), load_size);
 }
 ULongReader S4ReaderBuilder::openULongReader(std::string name) {
     NumericVector v = s4.slot(name);
     return DoubleReader(
-        std::make_unique<VecNumReader<double>>((double *)&v[0], v.size()), load_size
+        std::make_unique<VecNumReader<double>>(v.begin(), v.size()), load_size
     ).convert<uint64_t>();
 }
 FloatReader S4ReaderBuilder::openFloatReader(std::string name) {
     IntegerVector v = s4.slot(name);
-    return FloatReader(std::make_unique<VecNumReader<float>>((float *)&v[0], v.size()), load_size);
+    int32_t * data = v.begin();
+    return FloatReader(std::make_unique<VecNumReader<float>>((float *) data, v.size()), load_size);
 }
 DoubleReader S4ReaderBuilder::openDoubleReader(std::string name) {
     NumericVector v = s4.slot(name);
     return DoubleReader(
-        std::make_unique<VecNumReader<double>>((double *)&v[0], v.size()), load_size
+        std::make_unique<VecNumReader<double>>(v.begin(), v.size()), load_size
     );
 }
 std::unique_ptr<StringReader> S4ReaderBuilder::openStringReader(std::string name) {

--- a/r/tests/testthat/test-matrix_io.R
+++ b/r/tests/testthat/test-matrix_io.R
@@ -573,3 +573,14 @@ test_that("Opening >64 matrices works", {
   expect_identical(colSums(matrix_rbind), colSums(as(matrix_rbind, "dgCMatrix")))
   expect_identical(colSums(matrix_cbind), colSums(as(matrix_cbind, "dgCMatrix")))
 })
+
+test_that("Regression test for Rcpp out-of-bounds warning", {
+  m <- Matrix::sparseMatrix(i=1, j=1, x=1, dims=c(1,1)) %>% as("dgCMatrix")
+  expect_no_warning({
+    m2 <- m %>%
+      as("IterableMatrix") %>%
+      write_matrix_memory() %>%
+      as("dgCMatrix")
+  })
+  expect_identical(m, m2)
+})


### PR DESCRIPTION
Rcpp started warning about out-of-bounds access stating `subscript out of bounds (index 0 >= vector size 0)` on some tests. This was due to length-zero arrays in BPCells matrices arising from e.g. single element arrays with perfectly compressed data arrays (0 bits per element in the bitpacking data array).

Now we avoid accessing an index of a possibly-empty array and use an alternate method to get a data pointer.