### PR TITLE
enable setting HDF5_CFLAGS and HDF5_LIBS external to ./configure

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,6 +24,7 @@ Contributions welcome :)
 - `trackplot_loop()` now accepts discrete color scales
 - `trackplot_combine()` now has smarter layout logic for margins, as well as detecting when plots are being combined that cover different genomic regions. (pull request #116)
 - `select_cells()` and `select_chromosomes()` now also allow using a logical mask for selection. (pull request #117)
+- BPCells installation can now also be configured by setting the `LDFLAGS` or `CFLAGS` as environment variables in addition to setting them in `~/.R/Makevars` (pull request #124)
 
 ## Bug-fixes
 - Fixed error message when a matrix is too large to be converted to dgCMatrix. (Thanks to @RookieA1 for reporting issue #95)

--- a/r/configure
+++ b/r/configure
@@ -1,8 +1,9 @@
 #!/bin/bash
+
 if [ -z $BPCELLS_DEBUG_INSTALL ]; then 
-    ERR=/dev/null
+    exec 3>/dev/null
 else
-    ERR=/dev/stdout
+    exec 3>&1
     set -x
 fi
 
@@ -21,9 +22,11 @@ fi
 CC=$("${R_HOME}/bin/R" CMD config CC)
 CXX=$("${R_HOME}/bin/R" CMD config CXX)
 
-CFLAGS=$("${R_HOME}/bin/R" CMD config CFLAGS)
-CXXFLAGS=$("${R_HOME}/bin/R" CMD config CXXFLAGS)
-LDFLAGS=$("${R_HOME}/bin/R" CMD config LDFLAGS)
+ENV_CFLAGS="${CFLAGS-}"
+ENV_LDFLAGS="${LDFLAGS-}"
+CFLAGS="$("${R_HOME}/bin/R" CMD config CFLAGS) $ENV_CFLAGS"
+CXXFLAGS="$("${R_HOME}/bin/R" CMD config CXXFLAGS) $ENV_CFLAGS"
+LDFLAGS="$("${R_HOME}/bin/R" CMD config LDFLAGS) $ENV_LDFLAGS"
 ############################
 # HDF5 compatibility check
 ############################
@@ -31,17 +34,17 @@ LDFLAGS=$("${R_HOME}/bin/R" CMD config LDFLAGS)
 echo "Testing hdf5 by compiling example program..."
 
 # Vanilla install test
-HDF5_CFLAGS="${HDF5_CFLAGS-}"
-HDF5_LIBS="${HDF5_LIBS--lhdf5}"
+HDF5_CFLAGS=""
+HDF5_LIBS="-lhdf5"
 HDF5_OK=""
-$CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>$ERR && HDF5_OK="yes";
+$CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>&3 && HDF5_OK="yes";
 
 # pkg-config flags
 if [ -z $HDF5_OK ]; then
     printf "\n\nRetrying with pkg-config flags...\n"
-    if HDF5_CFLAGS="$(pkg-config hdf5 --cflags 2>$ERR)" && \
-        HDF5_LIBS="$(pkg-config hdf5 --libs 2>$ERR)"; then
-        $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>$ERR && HDF5_OK="yes";
+    if HDF5_CFLAGS="$(pkg-config hdf5 --cflags 2>&3)" && \
+        HDF5_LIBS="$(pkg-config hdf5 --libs 2>&3)"; then
+        $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>&3 && HDF5_OK="yes";
     else
         echo "Error running 'pkg-config hdf5 --cflags --libs'"
     fi
@@ -53,8 +56,8 @@ fi
 # The basic idea is to scrape -I, -L, -l, and -rpath arguments found from running h5cc -show and h5cc -showconfig
 if [ -z $HDF5_OK ]; then
     printf "\n\nSearching for config information with h5cc -showconfig and h5cc -show...\n"
-    if H5CC_CONFIG=$(h5cc -showconfig 2>$ERR) && \
-        H5CC_CONFIG=$(echo "$H5CC_CONFIG" | awk -F: '/FLAGS|Extra libraries:/ {printf("%s ", $2)}' 2>$ERR) &&\
+    if H5CC_CONFIG=$(h5cc -showconfig 2>&3) && \
+        H5CC_CONFIG=$(echo "$H5CC_CONFIG" | awk -F: '/FLAGS|Extra libraries:/ {printf("%s ", $2)}' 2>&3) &&\
         H5CC_CONFIG2=$(h5cc -show); then
         
         HDF5_CFLAGS=""
@@ -81,7 +84,7 @@ if [ -z $HDF5_OK ]; then
           esac
         done
         HDF5_LIBS="$HDF5_LIBS -lhdf5"
-        $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>$ERR && HDF5_OK="yes";
+        $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>&3 && HDF5_OK="yes";
     else
         echo "Failure running either 'h5cc -show' or: 'h5cc -showconfig | awk -F: '/FLAGS|Extra libraries:/ {printf("%s ", \$2)}'"
     fi
@@ -95,7 +98,7 @@ if [ -z $HDF5_OK ]; then
     else
         HDF5_CFLAGS="-I$CONDA_PREFIX/include"
         HDF5_LIBS="-Wl,-rpath,$CONDA_PREFIX/lib -L$CONDA_PREFIX/lib -lhdf5"
-        $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>$ERR && HDF5_OK="yes";
+        $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>&3 && HDF5_OK="yes";
     fi
 fi
 
@@ -114,11 +117,11 @@ echo "HDF5_LIBS='${HDF5_LIBS}'"
 CXX17_OK=""
 CXX_FS_FLAG=""
 printf "\nTesting C++17 filesystem feature support..."
-$CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>$ERR && CXX17_OK="yes";
+$CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>&3 && CXX17_OK="yes";
 if [ -z $CXX17_OK ]; then
     # Compiler support flag for gcc
     CXX_FS_FLAG="-lstdc++fs"
-    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>$ERR && CXX17_OK="yes";
+    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>&3 && CXX17_OK="yes";
     if [ ! -z $CXX17_OK ]; then
         printf "\nWarning: your compiler version is old, and may run in to compile errors with BPCells.\n"
         printf "Consider installing a newer compiler version and setting CC and CXX in ~/.R/Makevars\n"
@@ -129,7 +132,7 @@ fi
 if [ -z $CXX17_OK ]; then
     # Compiler support flag for llvm
     CXX_FS_FLAG="-lc++fs"
-    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>$ERR && CXX17_OK="yes";
+    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>&3 && CXX17_OK="yes";
     if [ ! -z $CXX17_OK ]; then
         printf "\nWarning: your compiler version is old, and may run in to compile errors with BPCells.\n"
         printf "Consider installing a newer compiler version and setting CC and CXX in ~/.R/Makevars\n"
@@ -149,7 +152,7 @@ printf "\nTesting availability of highway SIMD library..."
 HWY_OK=""
 HWY_CFLAGS="-Ibpcells-cpp"
 HWY_LIBS="-lhwy"
-$CXX tools/hwy-test.cpp $CXXFLAGS $LDFLAGS 2>$ERR && HWY_OK="yes";
+$CXX tools/hwy-test.cpp $CXXFLAGS $LDFLAGS 2>&3 && HWY_OK="yes";
 if [ -z $HWY_OK ]; then
     if [ ! -f tools/highway/lib/libhwy.a ]; then
         printf "\nBuilding highway SIMD library from source\n"
@@ -173,6 +176,8 @@ sed \
     -e "s|%CXX_FS_FLAG%|${CXX_FS_FLAG}|g" \
     -e "s|%HWY_CFLAGS%|${HWY_CFLAGS}|g" \
     -e "s|%HWY_LIBS%|${HWY_LIBS}|g" \
+    -e "s|%ENV_CFLAGS%|${ENV_CFLAGS}|g" \
+    -e "s|%ENV_LDFLAGS%|${ENV_LDFLAGS}|g" \
     src/Makevars.in > src/Makevars
 
 if [ -n $ENABLE_INSTALL_COUNTING ]; then

--- a/r/configure
+++ b/r/configure
@@ -31,8 +31,8 @@ LDFLAGS=$("${R_HOME}/bin/R" CMD config LDFLAGS)
 echo "Testing hdf5 by compiling example program..."
 
 # Vanilla install test
-HDF5_CFLAGS=""
-HDF5_LIBS="-lhdf5"
+HDF5_CFLAGS="${HDF5_CFLAGS-}"
+HDF5_LIBS="${HDF5_LIBS--lhdf5}"
 HDF5_OK=""
 $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>$ERR && HDF5_OK="yes";
 

--- a/r/configure.win
+++ b/r/configure.win
@@ -1,15 +1,9 @@
 #!/bin/bash
-if [ -z $BPCELLS_DEBUG_INSTALL ]; then 
-    ERR=/dev/null
-else
-    ERR=/dev/stdout
-    set -x
-fi
 
 if [ -z $BPCELLS_DEBUG_INSTALL ]; then 
-    ERR=/dev/null
+    exec 3>/dev/null
 else
-    ERR=/dev/stdout
+    exec 3>&1
     set -x
 fi
 
@@ -26,9 +20,11 @@ fi
 CC=$("${R_HOME}/bin/R" CMD config CC)
 CXX=$("${R_HOME}/bin/R" CMD config CXX)
 
-CFLAGS=$("${R_HOME}/bin/R" CMD config CFLAGS)
-CXXFLAGS=$("${R_HOME}/bin/R" CMD config CXXFLAGS)
-LDFLAGS=$("${R_HOME}/bin/R" CMD config LDFLAGS)
+ENV_CFLAGS="${CFLAGS-}"
+ENV_LDFLAGS="${LDFLAGS-}"
+CFLAGS="$("${R_HOME}/bin/R" CMD config CFLAGS) $ENV_CFLAGS"
+CXXFLAGS="$("${R_HOME}/bin/R" CMD config CXXFLAGS) $ENV_CFLAGS"
+LDFLAGS="$("${R_HOME}/bin/R" CMD config LDFLAGS) $ENV_LDFLAGS"
 ############################
 # HDF5 compatibility check
 ############################
@@ -65,11 +61,11 @@ echo "HDF5_LIBS='${HDF5_LIBS}'"
 CXX17_OK=""
 CXX_FS_FLAG=""
 printf "\nTesting C++17 filesystem feature support..."
-$CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>$ERR && CXX17_OK="yes";
+$CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>&3 && CXX17_OK="yes";
 if [ -z $CXX17_OK ]; then
     # Compiler support flag for gcc
     CXX_FS_FLAG="-lstdc++fs"
-    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>$ERR && CXX17_OK="yes";
+    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>&3 && CXX17_OK="yes";
     if [ ! -z $CXX17_OK ]; then
         printf "\nWarning: your compiler version is old, and may run in to compile errors with BPCells.\n"
         printf "Consider installing a newer compiler version and setting CC and CXX in ~/.R/Makevars\n"
@@ -80,13 +76,14 @@ fi
 if [ -z $CXX17_OK ]; then
     # Compiler support flag for llvm
     CXX_FS_FLAG="-lc++fs"
-    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>$ERR && CXX17_OK="yes";
+    $CXX tools/cxx17_filesystem.cc $CXXFLAGS $LDFLAGS -std=c++17 $CXX_FS_FLAG -o tools/cxx17_filesystem 2>&3 && CXX17_OK="yes";
     if [ ! -z $CXX17_OK ]; then
         printf "\nWarning: your compiler version is old, and may run in to compile errors with BPCells.\n"
         printf "Consider installing a newer compiler version and setting CC and CXX in ~/.R/Makevars\n"
         printf "\nUsed fallback compatibility flags for C++17 std::filesystem support: $CXX_FS_FLAG\n"
     fi
 fi
+
 if [ -z $CXX17_OK ]; then
     printf "\n\nUnable to compile program with C++17 std::filesystem.\nPlease install a newer compiler version and set CC and CXX in ~/.R/Makevars\n"
     exit 1
@@ -99,13 +96,13 @@ printf "\nTesting availability of highway SIMD library..."
 HWY_OK=""
 HWY_CFLAGS="-Ibpcells-cpp"
 HWY_LIBS="-lhwy"
-$CXX tools/hwy-test.cpp $CXXFLAGS $LDFLAGS 2>$ERR && HWY_OK="yes";
+$CXX tools/hwy-test.cpp $CXXFLAGS $LDFLAGS 2>&3 && HWY_OK="yes";
 if [ -z $HWY_OK ]; then
     if [ ! -f tools/highway/lib/libhwy.a ]; then
-        printf "\nBuilding highway SIMD library from source"
+        printf "\nBuilding highway SIMD library from source\n"
         CXX=$CXX bash src/vendor/highway/manual-build/build_highway.sh src/vendor/highway tools/highway && HWY_OK="yes";
     else
-        printf "\nUsing cached highway build"
+        printf "\nUsing cached highway build\n"
         HWY_OK="yes"
     fi
     HWY_CFLAGS="$HWY_CFLAGS -I../tools/highway/include"
@@ -123,6 +120,8 @@ sed \
     -e "s|%CXX_FS_FLAG%|${CXX_FS_FLAG}|g" \
     -e "s|%HWY_CFLAGS%|${HWY_CFLAGS}|g" \
     -e "s|%HWY_LIBS%|${HWY_LIBS}|g" \
+    -e "s|%ENV_CFLAGS%|${ENV_CFLAGS}|g" \
+    -e "s|%ENV_LDFLAGS%|${ENV_LDFLAGS}|g" \
     src/Makevars.in > src/Makevars
 
 if [ -n $ENABLE_INSTALL_COUNTING ]; then

--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -1,7 +1,7 @@
 # CXX_STD = CXX17
 
-PKG_CXXFLAGS = %HDF5_CFLAGS% %HWY_CFLAGS% -Ivendor -std=c++17 -DRCPP_EIGEN -DEIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS -Wno-ignored-attributes -Wno-unknown-pragmas # -Wall -Wextra -Wpedantic
-PKG_LIBS = -lz %HDF5_LIBS% %CXX_FS_FLAG% %HWY_LIBS%
+PKG_CXXFLAGS = %HDF5_CFLAGS% %HWY_CFLAGS% %ENV_CFLAGS% -Ivendor -std=c++17 -DRCPP_EIGEN -DEIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS -Wno-ignored-attributes -Wno-unknown-pragmas # -Wall -Wextra -Wpedantic
+PKG_LIBS = -lz %HDF5_LIBS% %CXX_FS_FLAG% %HWY_LIBS% %ENV_LDFLAGS%
 
 # PKG_CXXFLAGS = -Wno-deprecated-declarations -Wno-unused-but-set-variable -fsanitize=undefined %HDF5_CFLAGS% %HWY_CFLAGS% -std=c++17 -DRCPP_EIGEN -DEIGEN_PERMANENTLY_DISABLE_STUPID_WARNINGS -Wno-ignored-attributes -Wno-unknown-pragmas # -Wall -Wextra -Wpedantic
 # PKG_LIBS = -fsanitize=undefined -lz %HDF5_LIBS% %CXX_FS_FLAG% %HWY_LIBS%


### PR DESCRIPTION
The local `./configure` for BPCells does not have a mechanism for setting `HDF5_CFLAGS` and `HDF5_LIBS` external to the script, as do other `./configure` scripts; it relies only on its own internal mechanisms for determining the flags for interacting with hdf5. We do not provide hdf5 in the standard locations, but rather provide it from an Lmod module, so the include files and libraries for hdf5 are not in standard system locations..

This just uses a little bashiness to set the compilation and link flag variables to current environment variables if these are provided, otherwise it uses the current defaults.  With these changes, compilation against an hdf5 in a nonstandard location works correctly with

```
HDF5_CFLAGS="-I${HDF5_INCLUDE}" HDF5_LIBS="-L${HDF5_LIB} -lhdf5" R CMD INSTALL BPCells_0.2.0.tar.gz
```

assuming `HDF5_INCLUDE` is set to the hdf5 `.../include` directory and `HDF5_LIB` is set to its `.../lib` directory. Any other mechanism that can provide settings for these variables can be used to set these variables within the `./configure`.

This can address issues in #86 and #84.