### PR TITLE
Performance fix for BP-128 kernels

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_CXX_STANDARD 17)
 # add_link_options(-fsanitize=address -fsanitize=undefined)
 
 set(SRC bpcells-cpp)
+set(SRC_INCLUDE bpcells-cpp vendor)
 add_library(
     bitpacking 
     ${SRC}/simd/bp128/d1_maxbits.cpp
@@ -44,7 +45,7 @@ target_include_directories(
     bitpacking
     PUBLIC
     ${HWY_INCLUDE_DIRS}
-    ${SRC}
+    ${SRC_INCLUDE}
 )
 
 add_library(
@@ -59,7 +60,7 @@ target_include_directories(
     simd_math
     PUBLIC
     ${HWY_INCLUDE_DIRS}
-    ${SRC}
+    ${SRC_INCLUDE}
 )
 
 add_library(
@@ -74,7 +75,7 @@ target_include_directories(
     simd_overlaps
     PUBLIC
     ${HWY_INCLUDE_DIRS}
-    ${SRC}
+    ${SRC_INCLUDE}
 )
 
 
@@ -96,7 +97,7 @@ target_include_directories(
     arrayIO 
     PUBLIC 
     ${HDF5_INCLUDE_DIRS}
-    ${SRC}
+    ${SRC_INCLUDE}
 )
 
 add_library(
@@ -123,7 +124,7 @@ target_include_directories(
     fragmentIterators 
     PUBLIC 
     ${ZLIB_INCLUDE_DIRS}
-    ${SRC}
+    ${SRC_INCLUDE}
 )
 
 ### TESTING ###
@@ -177,6 +178,7 @@ add_executable(
     test-matrixIO
     tests/test-matrixIO.cpp
     ${SRC}/matrixIterators/ImportMatrixHDF5.cpp
+    ${SRC}/simd/dense-multiply.cpp
 )
 target_link_libraries(test-matrixIO arrayIO Eigen3::Eigen gtest_main gmock)
 gtest_discover_tests(test-matrixIO)
@@ -185,6 +187,7 @@ add_executable(
     test-matrixTranspose
     tests/test-matrixTranspose.cpp
     ${SRC}/matrixIterators/ImportMatrixHDF5.cpp
+    ${SRC}/simd/dense-multiply.cpp
 )
 target_link_libraries(test-matrixTranspose arrayIO Eigen3::Eigen gtest_main)
 gtest_discover_tests(test-matrixTranspose)
@@ -209,6 +212,7 @@ add_executable(test-matrixMath
     ${SRC}/matrixTransforms/Min.cpp
     ${SRC}/matrixTransforms/Scale.cpp
     ${SRC}/matrixTransforms/Shift.cpp
+    ${SRC}/simd/dense-multiply.cpp
 )
 
 target_include_directories(test-matrixMath PUBLIC ${SRC})
@@ -221,6 +225,7 @@ add_executable(
     ${SRC}/matrixIterators/PeakMatrix.cpp
     ${SRC}/matrixIterators/TileMatrix.cpp
     ${SRC}/simd/overlaps.cpp
+    ${SRC}/simd/dense-multiply.cpp
 )
 target_link_libraries(test-peakMatrix 
     Eigen3::Eigen

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
     ${SRC}/simd/bp128/vanilla_maxbits.cpp
     ${SRC}/simd/bp128/vanilla_pack.cpp
     ${SRC}/simd/bp128/vanilla_unpack.cpp
+    ${SRC}/simd/bp128/bp128-Nx128.cpp
 )
 target_link_libraries(
     bitpacking

--- a/cpp/tests/test-bp128.cpp
+++ b/cpp/tests/test-bp128.cpp
@@ -1,17 +1,19 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#include <functional>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <hwy/detect_targets.h>
-#include <hwy/targets.h>
 #include <hwy/highway.h>
+#include <hwy/targets.h>
 
 #include <simd/bp128.h>
 
@@ -122,15 +124,8 @@ void fill_buf(uint32_t *buf, int bits) {
         buf[i] = random_uint32_t() & mask;
     }
 }
-bool equal_buf(uint32_t *buf1, uint32_t *buf2) {
-    for (int i = 0; i < 128; i++) {
-        if (buf1[i] != buf2[i]) return false;
-    }
-    return true;
-}
-
-bool equal_buf(uint32_t *buf1, uint32_t *buf2, uint8_t bits) {
-    for (int i = 0; i < 4 * bits; i++) {
+bool equal_buf(uint32_t *buf1, uint32_t *buf2, uint32_t n = 128) {
+    for (int i = 0; i < n; i++) {
         if (buf1[i] != buf2[i]) return false;
     }
     return true;
@@ -146,7 +141,8 @@ TEST(Bitpacking, BP128) {
         hwy::SetSupportedTargetsForTest(target);
         for (int bits = 0; bits <= 32; bits++) {
             fill_buf(input_buf, bits);
-            fill_buf(packed_buf, 32); // fill the other bufs with garbage to avoid accidental success
+            // fill the other bufs with garbage to avoid accidental success
+            fill_buf(packed_buf, 32);
 
             EXPECT_FALSE(equal_buf(input_buf, output_buf))
                 << "Input and output aren't different before test, bits=" << bits;
@@ -158,16 +154,15 @@ TEST(Bitpacking, BP128) {
                 << "Packed ref and obs aren't different before test, bits=" << bits;
             simd::bp128::pack(input_buf, packed_buf, simd_bits);
             simd::bp128::unpack(packed_buf, output_buf, simd_bits);
-            
+
             pack128((uint32x4 *)input_buf, (uint32x4 *)ref_packed_buf, bits);
-            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits))
+            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits * 4))
                 << "Packed ref and obs are't identical after test, bits=" << bits;
-            
+
             if (bits > 0) {
                 EXPECT_TRUE(equal_buf(input_buf, output_buf))
                     << "Input buffer doesn't match output buffer, bits=" << bits;
             }
-
         }
     }
 }
@@ -182,7 +177,8 @@ TEST(Bitpacking, BP128d1) {
         hwy::SetSupportedTargetsForTest(target);
         for (int bits = 0; bits <= 32; bits++) {
             fill_buf(input_buf, bits);
-            fill_buf(packed_buf, 32); // fill the other bufs with garbage to avoid accidental success
+            // fill the other bufs with garbage to avoid accidental success
+            fill_buf(packed_buf, 32);
             uint32_t start_val = rand() & ((2 << 12) - 1);
             decode_d1(start_val, input_buf);
 
@@ -203,7 +199,7 @@ TEST(Bitpacking, BP128d1) {
                 << "Packed ref and obs aren't different before test, bits=" << bits;
             if (bits != 32) encode_d1(start_val, input_buf);
             pack128((uint32x4 *)input_buf, (uint32x4 *)ref_packed_buf, bits);
-            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits))
+            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits * 4))
                 << "Packed ref and obs are't identical after test, bits=" << bits;
         }
     }
@@ -220,7 +216,8 @@ TEST(Bitpacking, BP128d1z) {
         hwy::SetSupportedTargetsForTest(target);
         for (int bits = 0; bits <= 32; bits++) {
             fill_buf(input_buf, bits);
-            fill_buf(packed_buf, 32); // fill the other bufs with garbage to avoid accidental success
+            // fill the other bufs with garbage to avoid accidental success
+            fill_buf(packed_buf, 32);
             uint32_t start_val = rand() & ((2 << 12) - 1);
             decode_zigzag(input_buf);
             decode_d1(start_val, input_buf);
@@ -245,7 +242,7 @@ TEST(Bitpacking, BP128d1z) {
                 encode_zigzag(input_buf);
             }
             pack128((uint32x4 *)input_buf, (uint32x4 *)ref_packed_buf, bits);
-            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits))
+            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits * 4))
                 << "Packed ref and obs are't identical after test, bits=" << bits;
         }
     }
@@ -262,7 +259,8 @@ TEST(Bitpacking, BP128for) {
         hwy::SetSupportedTargetsForTest(target);
         for (int bits = 0; bits <= 32; bits++) {
             fill_buf(input_buf, bits);
-            fill_buf(packed_buf, 32); // fill the other bufs with garbage to avoid accidental success
+            // fill the other bufs with garbage to avoid accidental success
+            fill_buf(packed_buf, 32);
             uint32_t start_val = rand() & ((2 << 12) - 1);
             decode_for(start_val, input_buf);
 
@@ -271,7 +269,7 @@ TEST(Bitpacking, BP128for) {
 
             EXPECT_FALSE(equal_buf(packed_buf, ref_packed_buf))
                 << "Packed ref and obs aren't different before test, bits=" << bits;
-            
+
             int simd_bits = simd::bp128::maxbits_FOR(start_val, input_buf);
             EXPECT_EQ(simd_bits, bits) << "Wrong number of simdmaxbits";
 
@@ -286,7 +284,7 @@ TEST(Bitpacking, BP128for) {
                 encode_for(start_val, input_buf);
             }
             pack128((uint32x4 *)input_buf, (uint32x4 *)ref_packed_buf, bits);
-            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits))
+            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits * 4))
                 << "Packed ref and obs are't identical after test, bits=" << bits;
         }
     }
@@ -304,7 +302,8 @@ TEST(Bitpacking, BP128diff) {
         hwy::SetSupportedTargetsForTest(target);
         for (int bits = 0; bits <= 32; bits++) {
             fill_buf(input_buf, bits);
-            fill_buf(packed_buf, 32); // fill the other bufs with garbage to avoid accidental success
+            // fill the other bufs with garbage to avoid accidental success
+            fill_buf(packed_buf, 32);
             fill_buf(offsets, 12);
             decode_diff(offsets, input_buf);
 
@@ -313,7 +312,7 @@ TEST(Bitpacking, BP128diff) {
 
             EXPECT_FALSE(equal_buf(packed_buf, ref_packed_buf))
                 << "Packed ref and obs aren't different before test, bits=" << bits;
-            
+
             int simd_bits = simd::bp128::maxbits_diff(offsets, input_buf);
             EXPECT_EQ(simd_bits, bits) << "Wrong number of simdmaxbits";
 
@@ -328,8 +327,225 @@ TEST(Bitpacking, BP128diff) {
                 encode_diff(offsets, input_buf);
             }
             pack128((uint32x4 *)input_buf, (uint32x4 *)ref_packed_buf, bits);
-            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits))
+            EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, simd_bits * 4))
                 << "Packed ref and obs are't identical after test, bits=" << bits;
         }
+    }
+}
+
+// Fill in test input for bitpacking Nx128 tests, returning the number of integers written to
+// packed_buf
+uint32_t fill_Nx128_input(
+    uint32_t *input_buf,
+    uint32_t *packed_buf,
+    uint32_t *output_buf,
+    uint32_t *ref_packed_buf,
+    std::function<void(uint32_t *)> decode_func,
+    std::function<uint32_t(const uint32_t *)> maxbits_func,
+    std::function<void(uint32_t *)> edit_input_func
+) {
+    uint32_t *ref_packed_next = ref_packed_buf;
+    for (int bits = 0; bits <= 32; bits++) {
+        fill_buf(input_buf + 128 * bits, bits);
+        // fill the other bufs with garbage to avoid accidental success
+        fill_buf(packed_buf + 128 * bits, 32);
+        fill_buf(output_buf + 128 * bits, 32);
+
+        edit_input_func(input_buf + 128 * bits);
+
+        EXPECT_FALSE(equal_buf(input_buf + 128 * bits, output_buf + 128 * bits))
+            << "Input and output aren't different before test, bits=" << bits;
+        EXPECT_FALSE(equal_buf(packed_buf + 128 * bits, ref_packed_buf + 128 * bits))
+            << "Packed ref and obs aren't different before test, bits=" << bits;
+
+        if (bits != 32)
+            pack128((uint32x4 *)(input_buf + 128 * bits), (uint32x4 *)ref_packed_next, bits);
+        decode_func(input_buf + 128 * bits);
+        if (bits == 32) {
+            mempcpy(ref_packed_next, input_buf + 128 * bits, sizeof(uint32_t) * 128);
+        }
+
+        int simd_bits = maxbits_func(input_buf + 128 * bits);
+        EXPECT_EQ(simd_bits, bits) << "Wrong number of simdmaxbits";
+        ref_packed_next += 4 * bits;
+    }
+    return ref_packed_next - ref_packed_buf;
+}
+
+// Test the vectorized implementations
+TEST(Bitpacking, BP128_Nx128) {
+    uint32_t input_buf[128 * 33];
+    uint32_t packed_buf[128 * 33];
+    uint32_t ref_packed_buf[128 * 33];
+    uint32_t output_buf[128 * 33];
+    uint32_t bit[33];
+
+    for (int64_t target : hwy::SupportedAndGeneratedTargets()) {
+        hwy::SetSupportedTargetsForTest(target);
+        uint32_t *ref_packed_next = ref_packed_buf;
+        // Set up test input & output arrays
+        fill_Nx128_input(
+            input_buf,
+            packed_buf,
+            output_buf,
+            ref_packed_buf,
+            [](uint32_t *inout) {},
+            &simd::bp128::maxbits,
+            [](uint32_t *inout) {}
+        );
+
+        simd::bp128::pack_Nx128(33, input_buf, packed_buf, bit);
+        for (int bits = 0; bits <= 32; bits++) {
+            EXPECT_EQ(bits, bit[bits]) << "Stored bits count doesn't match";
+        }
+        EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, ref_packed_next - ref_packed_buf))
+            << "Packed bits don't match";
+
+        simd::bp128::unpack_Nx128(33, packed_buf, output_buf, bit);
+        EXPECT_TRUE(equal_buf(input_buf, output_buf, 128 * 33)) << "Unpacked bits don't match";
+    }
+}
+
+TEST(Bitpacking, BP128d1_Nx128) {
+    uint32_t input_buf[128 * 33];
+    uint32_t packed_buf[128 * 33];
+    uint32_t ref_packed_buf[128 * 33];
+    uint32_t output_buf[128 * 33];
+    uint32_t bit[33];
+    uint32_t initvalue[33];
+
+    for (int64_t target : hwy::SupportedAndGeneratedTargets()) {
+        hwy::SetSupportedTargetsForTest(target);
+        uint32_t *ref_packed_next = ref_packed_buf;
+        // Set up test input & output arrays
+        uint32_t start_val;
+        fill_Nx128_input(
+            input_buf,
+            packed_buf,
+            output_buf,
+            ref_packed_buf,
+            [&start_val](uint32_t *inout) { decode_d1(start_val, inout); },
+            [&start_val](const uint32_t *in) { return simd::bp128::maxbits_d1(start_val, in); },
+            [&start_val](uint32_t *inout) { inout[0] = 0;  start_val = rand() & ((2 << 12) - 1);}
+        );
+
+        simd::bp128::pack_d1_Nx128(33, initvalue, input_buf, packed_buf, bit);
+        for (int bits = 0; bits <= 32; bits++) {
+            EXPECT_EQ(bits, bit[bits]) << "Stored bits count doesn't match";
+            EXPECT_EQ(initvalue[bits], input_buf[128 * bits]) << "Stored initvalue doesn't match";
+        }
+        EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, ref_packed_next - ref_packed_buf))
+            << "Packed bits don't match";
+
+        simd::bp128::unpack_d1_Nx128(33, initvalue, packed_buf, output_buf, bit);
+        EXPECT_TRUE(equal_buf(input_buf, output_buf, 128 * 33)) << "Unpacked bits don't match";
+    }
+}
+
+TEST(Bitpacking, BP128d1z_Nx128) {
+    uint32_t input_buf[128 * 33];
+    uint32_t packed_buf[128 * 33];
+    uint32_t ref_packed_buf[128 * 33];
+    uint32_t output_buf[128 * 33];
+    uint32_t bit[33];
+    uint32_t initvalue[33];
+
+    for (int64_t target : hwy::SupportedAndGeneratedTargets()) {
+        hwy::SetSupportedTargetsForTest(target);
+        uint32_t *ref_packed_next = ref_packed_buf;
+        // Set up test input & output arrays
+        uint32_t start_val;
+        fill_Nx128_input(
+            input_buf,
+            packed_buf,
+            output_buf,
+            ref_packed_buf,
+            [&start_val](uint32_t *inout) { decode_zigzag(inout); decode_d1(start_val, inout); },
+            [&start_val](const uint32_t *in) { return simd::bp128::maxbits_d1z(start_val, in); },
+            [&start_val](uint32_t *inout) { inout[0] = 0;  start_val = rand() & ((2 << 12) - 1);}
+        );
+
+        simd::bp128::pack_d1z_Nx128(33, initvalue, input_buf, packed_buf, bit);
+        for (int bits = 0; bits <= 32; bits++) {
+            EXPECT_EQ(bits, bit[bits]) << "Stored bits count doesn't match";
+            EXPECT_EQ(initvalue[bits], input_buf[128 * bits]) << "Stored initvalue doesn't match";
+        }
+        EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, ref_packed_next - ref_packed_buf))
+            << "Packed bits don't match";
+
+        simd::bp128::unpack_d1z_Nx128(33, initvalue, packed_buf, output_buf, bit);
+        EXPECT_TRUE(equal_buf(input_buf, output_buf, 128 * 33)) << "Unpacked bits don't match";
+    }
+}
+
+TEST(Bitpacking, BP128for_Nx128) {
+    uint32_t input_buf[128 * 33];
+    uint32_t packed_buf[128 * 33];
+    uint32_t ref_packed_buf[128 * 33];
+    uint32_t output_buf[128 * 33];
+    uint32_t bit[33];
+    uint32_t initvalue[33];
+
+    for (int64_t target : hwy::SupportedAndGeneratedTargets()) {
+        hwy::SetSupportedTargetsForTest(target);
+        uint32_t *ref_packed_next = ref_packed_buf;
+        // Set up test input & output arrays
+        uint32_t start_val = rand() & ((2 << 12) - 1);
+        fill_Nx128_input(
+            input_buf,
+            packed_buf,
+            output_buf,
+            ref_packed_buf,
+            [start_val](uint32_t *inout) { decode_for(start_val, inout); },
+            [start_val](const uint32_t *in) { return simd::bp128::maxbits_FOR(start_val, in); },
+            [](uint32_t *inout) { }
+        );
+
+        simd::bp128::pack_FOR_Nx128(33, start_val, input_buf, packed_buf, bit);
+        for (int bits = 0; bits <= 32; bits++) {
+            EXPECT_EQ(bits, bit[bits]) << "Stored bits count doesn't match";
+        }
+        EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, ref_packed_next - ref_packed_buf))
+            << "Packed bits don't match";
+
+        simd::bp128::unpack_FOR_Nx128(33, start_val, packed_buf, output_buf, bit);
+        EXPECT_TRUE(equal_buf(input_buf, output_buf, 128 * 33)) << "Unpacked bits don't match";
+    }
+}
+
+TEST(Bitpacking, BP128diff_Nx128) {
+    uint32_t input_buf[128 * 33];
+    uint32_t packed_buf[128 * 33];
+    uint32_t ref_packed_buf[128 * 33];
+    uint32_t output_buf[128 * 33];
+    uint32_t bit[33];
+    uint32_t initvalue[33];
+    uint32_t offsets[128 * 33];
+
+    for (int64_t target : hwy::SupportedAndGeneratedTargets()) {
+        hwy::SetSupportedTargetsForTest(target);
+        uint32_t *ref_packed_next = ref_packed_buf;
+        // Set up test input & output arrays
+        int chunk = -1;
+        
+        fill_Nx128_input(
+            input_buf,
+            packed_buf,
+            output_buf,
+            ref_packed_buf,
+            [&offsets, &chunk](uint32_t *inout) { decode_diff(offsets + 128*chunk, inout); },
+            [&offsets, &chunk](const uint32_t *in) { return simd::bp128::maxbits_diff(offsets + 128*chunk, in); },
+            [&offsets, &chunk](uint32_t *inout) {chunk += 1; fill_buf(offsets + 128*chunk, 12);}
+        );
+
+        simd::bp128::pack_diff_Nx128(33, offsets, input_buf, packed_buf, bit);
+        for (int bits = 0; bits <= 32; bits++) {
+            EXPECT_EQ(bits, bit[bits]) << "Stored bits count doesn't match";
+        }
+        EXPECT_TRUE(equal_buf(packed_buf, ref_packed_buf, ref_packed_next - ref_packed_buf))
+            << "Packed bits don't match";
+
+        simd::bp128::unpack_diff_Nx128(33, offsets, packed_buf, output_buf, bit);
+        EXPECT_TRUE(equal_buf(input_buf, output_buf, 128 * 33)) << "Unpacked bits don't match";
     }
 }

--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -53,6 +53,7 @@ bpcells-cpp/matrixTransforms/Scale.o \
 bpcells-cpp/matrixTransforms/Shift.o \
 bpcells-cpp/matrixUtils/WilcoxonRankSum.o \
 bpcells-cpp/simd/bp128/current_target.o \
+bpcells-cpp/simd/bp128/bp128-Nx128.o \
 bpcells-cpp/simd/bp128/d1_maxbits.o \
 bpcells-cpp/simd/bp128/d1_pack.o \
 bpcells-cpp/simd/bp128/d1_unpack.o \

--- a/r/src/bpcells-cpp/simd/bp128.h
+++ b/r/src/bpcells-cpp/simd/bp128.h
@@ -176,6 +176,141 @@ uint32_t maxbits_diff(const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_REST
 
 
 /**
+ * @brief Unpack N*128 bitpacked 32-bit integers
+ * 
+ * @param n Number of 128-integer chunks
+ * @param in (in, length sum(bit)*4)pointer to bitpacked integers
+ * @param out (out, length N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (in, length N) pointer to number of bits per integer
+ */
+void unpack_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit);
+/**
+ * @brief Bitpack N*128 32-bit integers
+ * 
+ * Calculate optimal bitwidth for each of N 128-integer chunk (stored to bit), then write bitpacked data to out.
+ * 
+ * @param n Number of 128-integer chunks
+ * @param in (in, length N*128) pointer to input integers
+ * @param out (out, capacity N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (out, length N) pointer to number of bits per integer
+ */
+void pack_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit);
+
+
+/**
+ * @brief Unpack N*128 bitpacked 32-bit integers with d1 encoding
+ * 
+ * For d1 encoding, take the difference between adjacent inputs prior to packing
+ * 
+ * @param n Number of 128-integer chunks
+ * @param initvalue (in, length N) Value to be subtracted from the fist input
+ * @param in (in, length sum(bit)*4)pointer to bitpacked integers
+ * @param out (out, length N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (in, length N) pointer to number of bits per integer
+ */
+void unpack_d1_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit);
+/**
+ * @brief Bitpack 128 32-bit integers with d1 encoding
+ * 
+ * Calculate optimal bitwidth for each of N 128-integer chunk (stored to bit), then write bitpacked data to out.
+ * 
+ * For d1 encoding, take the difference between adjacent inputs prior to packing. Uses the first value from each
+ * chunk of 128 as the initvalue.
+ * 
+ * @param n Number of 128-integer chunks
+ * @param initvalue (out, length N) Value to be subtracted from the fist input during unpacking
+ * @param in (in, length N*128) pointer to input integers
+ * @param out (out, capacity N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (out, length N) pointer to number of bits per integer
+ */
+void pack_d1_Nx128(uint32_t n, uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit);
+
+
+/**
+ * @brief Unpack N*128 bitpacked 32-bit integers with d1z encoding
+ * 
+ * For d1z encoding, take the difference between adjacent inputs, then
+ * zigzag encode (0,-1,1,-2,2...) -> (0,1,2,3,4,...)
+ * 
+ * @param n Number of 128-integer chunks
+ * @param initvalue (in, length N) Value to be subtracted from the fist input
+ * @param in (in, length sum(bit)*4)pointer to bitpacked integers
+ * @param out (out, length N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (in, length N) pointer to number of bits per integer
+ */
+void unpack_d1z_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit);
+
+/**
+ * @brief Bitpack N*128 32-bit integers with d1z encoding
+ * 
+ * Calculate optimal bitwidth for each of N 128-integer chunk (stored to bit), then write bitpacked data to out.
+ * 
+ * For d1z encoding, take the difference between adjacent inputs, then
+ * zigzag encode (0,-1,1,-2,2...) -> (0,1,2,3,4,...)
+ * Uses the first value from each chunk of 128 as the initvalue.
+ * 
+ * @param n Number of 128-integer chunks
+ * @param initvalue (out, length N) Value to be subtracted from the fist input
+ * @param in (in, length N*128) pointer to input integers
+ * @param out (out, capacity N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (out, length N) pointer to number of bits per integer
+ */
+void pack_d1z_Nx128(uint32_t n, uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit);
+
+
+/**
+ * @brief Unpack N*128 bitpacked 32-bit integers with frame of reference encoding
+ * 
+ * For frame of reference encoding, subtract a constant from inputs prior to packing
+ * 
+ * @param n Number of 128-integer chunks
+ * @param offset Value to apply as offset
+ * @param in (in, length sum(bit)*4)pointer to bitpacked integers
+ * @param out (out, length N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (in, length N) pointer to number of bits per integer
+ */
+void unpack_FOR_Nx128(uint32_t n, uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit);
+/**
+ * @brief Bitpack N*128 32-bit integers with frame of reference encoding
+ * 
+ * For frame of reference encoding, subtract a constant from inputs prior to packing
+ * 
+ * @param n Number of 128-integer chunks
+ * @param offset Value to apply as offset
+ * @param in (in, length N*128) pointer to input integers
+ * @param out (out, capacity N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (out, length N) pointer to number of bits per integer
+ */
+void pack_FOR_Nx128(uint32_t n, uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit);
+
+
+/**
+ * @brief Unpack N*128 bitpacked 32-bit integers with difference-from-reference encoding
+ * 
+ * For difference-from-reference encoding, subtract a vector of 128 integers prior to encoding
+ * 
+ * @param n Number of 128-integer chunks
+ * @param ref (in, length N*128) pointer to 128 values to use as offset
+ * @param in (in, length sum(bit)*4)pointer to bitpacked integers
+ * @param out (out, length N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (in, length N) pointer to number of bits per integer
+ */
+void unpack_diff_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit);
+/**
+ * @brief Bitpack N*128 32-bit integers with difference-from-reference encoding
+ * 
+ * For difference-from-reference encoding, subtract a vector of 128 integers prior to encoding
+ * 
+ * @param n Number of 128-integer chunks
+ * @param ref (in, length N*128) pointer to 128 values to use as offset
+ * @param in (in, length N*128) pointer to input integers
+ * @param out (out, capacity N*128) pointer to output destination (must be non-overlapping with input!)
+ * @param bit (out, length N) pointer to number of bits per integer
+ */
+void pack_diff_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit);
+
+
+/**
  * @brief Return the current target (SIMD feature set) used for bp128 operations
  * 
  * @return const char* 

--- a/r/src/bpcells-cpp/simd/bp128.h
+++ b/r/src/bpcells-cpp/simd/bp128.h
@@ -13,6 +13,17 @@
 
 namespace BPCells::simd::bp128 {
 
+
+// ##############################################################################
+// #                           REFERENCE RESOURCES                              #
+// ##############################################################################
+// - Original BP-128 paper by Daniel Lemire: https://arxiv.org/pdf/1209.2137
+// - Check out pack128 and unpack128 from the tests in `test-bp128.cpp` for an easy-to-read implementation
+//   of the vanilla BP-128 logic
+// - Daniel Lemire repo with some of these functions implemented: https://github.com/lemire/simdcomp
+//    - A bit tough to read, but was an important reference for the original implementation
+
+
 /**
  * @brief Unpack 128 bitpacked 32-bit integers
  * 

--- a/r/src/bpcells-cpp/simd/bp128/bp128-Nx128.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/bp128-Nx128.cpp
@@ -1,0 +1,216 @@
+// Copyright 2024 BPCells contributors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Compilation speed is a concern, hence why each bp128 function is split up (better
+// parallelization). This is because 32-step unrolled loop * 32 bitwidths * 6 functions * 6-8
+// architectures = a lot of code When in debug mode AND optimize is turned off, disable dynamic
+// dispatch and compile for just baseline architecture
+#if !defined(NDEBUG) && !defined(__OPTIMIZE__)
+#define HWY_COMPILE_ONLY_STATIC 1
+#endif
+
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "simd/bp128/bp128-Nx128.cpp"
+#include <hwy/foreach_target.h>
+
+#include <hwy/highway.h>
+
+HWY_BEFORE_NAMESPACE();
+
+namespace BPCells::simd::bp128::HWY_NAMESPACE {
+
+void unpack_bp128(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+void pack_bp128(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+uint32_t maxbits_bp128(const uint32_t *HWY_RESTRICT in);
+
+extern void unpack_d1(uint32_t initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern void pack_d1(uint32_t initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern uint32_t maxbits_d1(uint32_t initvalue, const uint32_t *HWY_RESTRICT in);
+
+extern void unpack_d1z(uint32_t initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern void pack_d1z(uint32_t initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern uint32_t maxbits_d1z(uint32_t initvalue, const uint32_t *HWY_RESTRICT in);
+
+extern void unpack_FOR(uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern void pack_FOR(uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern uint32_t maxbits_FOR(uint32_t offset, const uint32_t *HWY_RESTRICT in);
+
+extern void unpack_diff(const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern void pack_diff(const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit);
+extern uint32_t maxbits_diff(const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in);
+
+void pack_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t b = maxbits_bp128(in);
+        pack_bp128(in, out, b);
+        
+        bit[i] = b;
+
+        in += 128,
+        out += b*4;
+    }
+}
+
+void unpack_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        unpack_bp128(in, out, bit[i]);
+
+        in += bit[i]*4;
+        out += 128;
+    }
+}
+
+void pack_d1_Nx128(uint32_t n, uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t b = maxbits_d1(in[0], in);
+        pack_d1(in[0], in, out, b);
+        
+        bit[i] = b;
+        initvalue[i] = in[0];
+
+        in += 128,
+        out += b*4;
+    }
+}
+
+void unpack_d1_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        unpack_d1(initvalue[i], in, out, bit[i]);
+
+        in += bit[i]*4;
+        out += 128;
+    }
+}
+
+void pack_d1z_Nx128(uint32_t n, uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t b = maxbits_d1z(in[0], in);
+        pack_d1z(in[0], in, out, b);
+        
+        bit[i] = b;
+        initvalue[i] = in[0];
+
+        in += 128,
+        out += b*4;
+    }
+}
+
+void unpack_d1z_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        unpack_d1z(initvalue[i], in, out, bit[i]);
+
+        in += bit[i]*4;
+        out += 128;
+    }
+}
+
+void pack_FOR_Nx128(uint32_t n, uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t b = maxbits_FOR(offset, in);
+        pack_FOR(offset, in, out, b);
+        
+        bit[i] = b;
+
+        in += 128,
+        out += b*4;
+    }
+}
+
+void unpack_FOR_Nx128(uint32_t n, uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        unpack_FOR(offset, in, out, bit[i]);
+
+        in += bit[i]*4;
+        out += 128;
+    }
+}
+
+void pack_diff_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t b = maxbits_diff(ref + 128*i, in);
+        pack_diff(ref + 128*i, in, out, b);
+        
+        bit[i] = b;
+
+        in += 128,
+        out += b*4;
+    }
+}
+
+
+void unpack_diff_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    for (uint32_t i = 0; i < n; i++) {
+        unpack_diff(ref + 128*i, in, out, bit[i]);
+
+        in += bit[i]*4;
+        out += 128;
+    }
+}
+
+
+} // namespace BPCells::simd::bp128::HWY_NAMESPACE
+
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace BPCells::simd::bp128 {
+
+HWY_EXPORT(pack_Nx128);
+HWY_EXPORT(unpack_Nx128);
+HWY_EXPORT(pack_d1_Nx128);
+HWY_EXPORT(unpack_d1_Nx128);
+HWY_EXPORT(pack_d1z_Nx128);
+HWY_EXPORT(unpack_d1z_Nx128);
+HWY_EXPORT(pack_FOR_Nx128);
+HWY_EXPORT(unpack_FOR_Nx128);
+HWY_EXPORT(pack_diff_Nx128);
+HWY_EXPORT(unpack_diff_Nx128);
+
+void pack_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(pack_Nx128)(n, in, out, bit);
+}
+
+void unpack_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(unpack_Nx128)(n, in, out, bit);
+}
+
+void pack_d1_Nx128(uint32_t n, uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(pack_d1_Nx128)(n, initvalue, in, out, bit);
+}
+
+void unpack_d1_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(unpack_d1_Nx128)(n, initvalue, in, out, bit);
+}
+
+void pack_d1z_Nx128(uint32_t n, uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(pack_d1z_Nx128)(n, initvalue, in, out, bit);
+}
+
+void unpack_d1z_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT initvalue, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(unpack_d1z_Nx128)(n, initvalue, in, out, bit);
+}
+
+void pack_FOR_Nx128(uint32_t n, uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(pack_FOR_Nx128)(n, offset, in, out, bit);
+}
+
+void unpack_FOR_Nx128(uint32_t n, uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(unpack_FOR_Nx128)(n, offset, in, out, bit);
+}
+
+void pack_diff_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(pack_diff_Nx128)(n, ref, in, out, bit);
+}
+
+void unpack_diff_Nx128(uint32_t n, const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t *HWY_RESTRICT bit) {
+    HWY_DYNAMIC_DISPATCH(unpack_diff_Nx128)(n, ref, in, out, bit);
+}
+
+} // namespace BPCells::simd::bp128
+#endif
+

--- a/r/src/bpcells-cpp/simd/bp128/bp128-helper-inl.h
+++ b/r/src/bpcells-cpp/simd/bp128/bp128-helper-inl.h
@@ -1,5 +1,5 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -24,156 +24,230 @@ HWY_BEFORE_NAMESPACE();
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
 // ##############################################################################
-// #                  MANUAL LOOP UNROLL TEMPLATES                              #
-// ##############################################################################
-
-// How this works: The main "unroll" function takes a one-parameter lambda with signature void
-// f(auto i). This `i` can be converted into a constexpr integer automatically.
-//
-// There are two requirements that add up to this solution:
-//   1. The performance of the BP128 function is dependent on full loop unrolling, which is
-//   otherwise hard to
-//      force a compiler to do. The alternative is a mix of unrolling macros + templates, which I've
-//      moved away from for clarity at the call-site.
-//   2. The hwy::ShiftLeft and hwy::ShiftRight functions require a comptime-known shift as a
-//   template parameter.
-//
-// From some testing on godbolt.org, it seems like this lambda style will be fully inlined for
-// optimization levels -O1 and above. I'm fine with this given that it enables much less code
-// duplication for all the BP128 variants
-template <int N> struct ComptimeInteger {
-    constexpr operator int() const { return N; }
-};
-
-template <int... inds, class F> void unroll_helper(F &&f, std::integer_sequence<int, inds...>) {
-    // This is C++17 "pack expansion" with an expression called once per integer input
-    (f(ComptimeInteger<inds>{}), ...);
-}
-
-template <class F> constexpr void unroll32(F &&f) {
-    unroll_helper(std::forward<F>(f), std::make_integer_sequence<int, 32>{});
-}
-
-// ##############################################################################
-// #                    BP128 CODEC CORE TEMPLATES                              #
+// #                              HELPER MACROS                                 #
 // ##############################################################################
 
 /**
- * @brief Generic BP128 unpacking. Unpacks 128 integers with known bitwidth.
- *
- * @tparam B Number of bits per integer
- * @tparam F Lambda function type
- * @param in Bitpacked data
- * @param out Uncompressed data
- * @param unpack_transform One-argument function that transforms the result just prior to output
+ * Note: A previous attempt did this all with nice template functions and closures
+ * (immediately after the Genentech code incorporation).
+ * That proved to not inline everything as desired, so now there's a big mess of macros to handle
+ * code generation. The macros have very specific, somewhat unusual argument requirements, though
+ * these are documented by each macro and should be easy to follow from examples.
  */
-template <unsigned B, class F>
-void unpack(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, F &&unpack_transform) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
 
-    D d;
-
-    // Handle special cases here, since we can't give partial specialization for functions
-    if constexpr (B == 0) {
-        unroll32([&out, &unpack_transform, d](auto i) {
-            StoreU(unpack_transform(Zero(d)), d, out + i*4);
-        });
-        return;
-    }
-    if constexpr (B == 32) {
-        memcpy(out, in, sizeof(uint32_t) * 128);
-        return;
+// BP128_UNROLL_LOOP32(counter, body) will repeat `body` 32 times, with interleaved `counter = i`
+// lines
+#define BP128_UNROLL_LOOP1(start, counter, body)                                                   \
+    {                                                                                              \
+        [[maybe_unused]] constexpr int counter = start;                                            \
+        body                                                                                       \
     }
 
-    Vec InReg, OutReg;
-    Vec mask = Set(d, B < 32 ? (1U << B) - 1 : 0xffffffff);
+#define BP128_UNROLL_LOOP4(start, counter, body)                                                   \
+    BP128_UNROLL_LOOP1((start + 0), counter, body)                                                 \
+    BP128_UNROLL_LOOP1((start + 1), counter, body)                                                 \
+    BP128_UNROLL_LOOP1((start + 2), counter, body)                                                 \
+    BP128_UNROLL_LOOP1((start + 3), counter, body)
 
-    unroll32([&in, &out, &unpack_transform, d, mask, &InReg, &OutReg](auto i) {
-        constexpr int shift = (i * B) & 31;
-        if constexpr (shift == 0) {
-            InReg = LoadU(d, in);
-            in += 4;
-            OutReg = InReg;
-        } else {
-            OutReg = ShiftRight<shift>(InReg);
-        }
+#define BP128_UNROLL_LOOP32(counter, body)                                                         \
+    BP128_UNROLL_LOOP4(0, counter, body)                                                           \
+    BP128_UNROLL_LOOP4(4, counter, body)                                                           \
+    BP128_UNROLL_LOOP4(8, counter, body)                                                           \
+    BP128_UNROLL_LOOP4(12, counter, body)                                                          \
+    BP128_UNROLL_LOOP4(16, counter, body)                                                          \
+    BP128_UNROLL_LOOP4(20, counter, body)                                                          \
+    BP128_UNROLL_LOOP4(24, counter, body)                                                          \
+    BP128_UNROLL_LOOP4(28, counter, body)
 
-        if constexpr (shift > 32 - B) {
-            InReg = LoadU(d, in);
-            in += 4;
-            OutReg = Or(OutReg, ShiftLeft<32 - shift>(InReg));
-        }
+// BP_SWITCH_CASE31 will switch over a variable for case 1: ... case 31:
+// ARGS_IN_PARENS should be a list of arguments already enclosed in parens, e.g. `(arg1, arg2,
+// arg3)`
+#define BP128_SWITCH_CASE(i, function, ARGS_IN_PARENS)                                             \
+    case i:                                                                                        \
+        function<i> ARGS_IN_PARENS;                                                                \
+        break;
 
-        OutReg = And(OutReg, mask);
+#define BP128_SWITCH_CASE4(start, function, ARGS_IN_PARENS)                                        \
+    BP128_SWITCH_CASE((start + 0), function, ARGS_IN_PARENS)                                       \
+    BP128_SWITCH_CASE((start + 1), function, ARGS_IN_PARENS)                                       \
+    BP128_SWITCH_CASE((start + 2), function, ARGS_IN_PARENS)                                       \
+    BP128_SWITCH_CASE((start + 3), function, ARGS_IN_PARENS)
 
-        OutReg = unpack_transform(OutReg);
+#define BP128_SWITCH_CASE31(function, ARGS_IN_PARENS)                                              \
+    BP128_SWITCH_CASE4(1, function, ARGS_IN_PARENS)                                                \
+    BP128_SWITCH_CASE4(5, function, ARGS_IN_PARENS)                                                \
+    BP128_SWITCH_CASE4(9, function, ARGS_IN_PARENS)                                                \
+    BP128_SWITCH_CASE4(13, function, ARGS_IN_PARENS)                                               \
+    BP128_SWITCH_CASE4(17, function, ARGS_IN_PARENS)                                               \
+    BP128_SWITCH_CASE4(21, function, ARGS_IN_PARENS)                                               \
+    BP128_SWITCH_CASE4(25, function, ARGS_IN_PARENS)                                               \
+    BP128_SWITCH_CASE(29, function, ARGS_IN_PARENS)                                                \
+    BP128_SWITCH_CASE(30, function, ARGS_IN_PARENS)                                                \
+    BP128_SWITCH_CASE(31, function, ARGS_IN_PARENS)
 
-        StoreU(OutReg, d, out);
-        out += 4;
-    });
-}
+// ##############################################################################
+// #                     BP128 CODEC CORE MACROS                                #
+// ##############################################################################
 
-/**
- * @brief Generic BP128 unpacking. Unpacks 128 integers with known bitwidth.
+/** BP128_PACK_DECL helps to declare bitpacking functions with full unrolling.
  *
- * @tparam B Number of bits per integer
- * @tparam MASK If true, then apply masking prior to packing for safety with too-large values
- * @tparam F Lambda function type
- * @param in Uncompressed data
- * @param out Bitpacked data
- * @param pack_transform One-argument function that transforms the result prior to bitpacking
+ * Declares FN_NAME_static, which is templated with a static bitwidth and
+ * FN_NAME, which takes a dynamic bitwidth as its final parameter.
+ *
+ * No masking of input data is performed, so inputs that require higher than specified number
+ * of bits will mess up adjacent values.
+ *
+ * @param FN_NAME (variable name) Name to use for the output function
+ * @param setup (code block) Code to run setup just prior to starting the bitpacking loop
+ * @param pack_transform (code block) Code block that applies transforms on `InReg` prior to
+ * bitpacking, re-assinging the result to the `InReg` variable
+ * @param CALL_ARGS_IN_PARENS (parameter list in parens) List of the parameter names in function
+ * signature without types, e.g. `(in, out)`
+ * @param ... Function signature. Must be at least: `const uint32_t *HWY_RESTRICT in, uint32_t
+ * *HWY_RESTRICT out`
+ *
  */
-template <unsigned B, bool MASK, class F>
-void pack(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, F &&pack_transform) {
-    // Handle special cases here, since we can't give partial specialization for functions
-    if constexpr (B == 0) {
-        return;
+#define BP128_PACK_DECL(FN_NAME, setup, pack_transform, CALL_ARGS_IN_PARENS, ...)                  \
+    template <unsigned BITS> void FN_NAME##_static(__VA_ARGS__) {                                  \
+        using namespace hwy::HWY_NAMESPACE;                                                        \
+        using D = Full128<uint32_t>;                                                               \
+        using Vec = Vec<D>;                                                                        \
+        D d;                                                                                       \
+        Vec InReg, OutReg;                                                                         \
+        setup;                                                                                     \
+        BP128_UNROLL_LOOP32(i, {                                                                   \
+            constexpr int shift = (i * BITS) & 31;                                                 \
+            InReg = LoadU(d, in);                                                                  \
+            in += 4;                                                                               \
+            pack_transform;                                                                        \
+            if constexpr (shift == 0) {                                                            \
+                OutReg = InReg;                                                                    \
+            } else {                                                                               \
+                OutReg = Or(OutReg, ShiftLeft<shift>(InReg));                                      \
+            }                                                                                      \
+            if constexpr (shift >= 32 - BITS) {                                                    \
+                StoreU(OutReg, d, out);                                                            \
+                out += 4;                                                                          \
+                if (shift > 32 - BITS) {                                                           \
+                    OutReg = ShiftRight<32 - shift>(InReg);                                        \
+                }                                                                                  \
+            }                                                                                      \
+        })                                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    void FN_NAME(__VA_ARGS__, const uint32_t bit) {                                                \
+        switch (bit) {                                                                             \
+        case 0:                                                                                    \
+            break;                                                                                 \
+            /* Cases 1 to 31 */                                                                    \
+            BP128_SWITCH_CASE31(FN_NAME##_static, CALL_ARGS_IN_PARENS)                             \
+        case 32:                                                                                   \
+            memcpy(out, in, sizeof(uint32_t) * 128);                                               \
+        }                                                                                          \
     }
-    if constexpr (B == 32) {
-        memcpy(out, in, sizeof(uint32_t) * 128);
-        return;
+
+/** BP128_UNPACK_DECL helps to declare bit-unpacking functions with full unrolling.
+ *
+ * Declares FN_NAME_static, which is templated with a static bitwidth and
+ * FN_NAME, which takes a dynamic bitwidth as its final parameter.
+ *
+ * @param FN_NAME (variable name) Name to use for the output function
+ * @param setup (code block) Code to run setup just prior to starting the bitpacking loop
+ * @param unpack_transform (code block) Code block that applies transforms on `OutReg` after
+ * unpacking, re-assinging the result to the `OutReg` variable
+ * @param CALL_ARGS_IN_PARENS (parameter list in parens) List of the parameter names in function
+ * signature without types, e.g. `(in, out)`
+ * @param ... Function signature. Must be at least: `const uint32_t *HWY_RESTRICT in, uint32_t
+ * *HWY_RESTRICT out`
+ *
+ */
+#define BP128_UNPACK_DECL(FN_NAME, setup, unpack_transform, CALL_ARGS_IN_PARENS, ...)              \
+    template <unsigned BITS> void FN_NAME##_static(__VA_ARGS__) {                                           \
+        using namespace hwy::HWY_NAMESPACE;                                                        \
+        using D = Full128<uint32_t>;                                                               \
+        using Vec = Vec<D>;                                                                        \
+        D d;                                                                                       \
+        Vec InReg, OutReg;                                                                         \
+        Vec mask = Set(d, BITS < 32 ? (1U << BITS) - 1 : 0xffffffff);                              \
+        setup;                                                                                     \
+        BP128_UNROLL_LOOP32(i, {                                                                   \
+            constexpr int shift = (i * BITS) & 31;                                                 \
+            if constexpr (shift == 0) {                                                            \
+                InReg = LoadU(d, in);                                                              \
+                in += 4;                                                                           \
+                OutReg = InReg;                                                                    \
+            } else {                                                                               \
+                OutReg = ShiftRight<shift>(InReg);                                                 \
+            }                                                                                      \
+            if constexpr (shift > 32 - BITS) {                                                     \
+                InReg = LoadU(d, in);                                                              \
+                in += 4;                                                                           \
+                OutReg = Or(OutReg, ShiftLeft<32 - shift>(InReg));                                 \
+            }                                                                                      \
+            OutReg = And(OutReg, mask);                                                            \
+            unpack_transform;                                                                      \
+            StoreU(OutReg, d, out);                                                                \
+            out += 4;                                                                              \
+        })                                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    void FN_NAME(__VA_ARGS__, uint32_t bit) {                                                      \
+        switch (bit) {                                                                             \
+        case 0: {                                                                                  \
+            using namespace hwy::HWY_NAMESPACE;                                                    \
+            using D = Full128<uint32_t>;                                                           \
+            using Vec = Vec<D>;                                                                    \
+            D d;                                                                                   \
+            setup;                                                                                 \
+            BP128_UNROLL_LOOP32(i, {                                                               \
+                Vec OutReg = Zero(d);                                                              \
+                unpack_transform;                                                                  \
+                StoreU(OutReg, d, out + i * 4);                                                    \
+            })                                                                                     \
+            break;                                                                                 \
+        }                                                                                          \
+            BP128_SWITCH_CASE31(FN_NAME##_static, CALL_ARGS_IN_PARENS)                                      \
+        case 32:                                                                                   \
+            memcpy(out, in, sizeof(uint32_t) * 128);                                               \
+            break;                                                                                 \
+        }                                                                                          \
     }
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
 
-    D d;
-    Vec InReg, OutReg;
-    Vec mask = Set(d, B < 32 ? (1U << B) - 1 : 0xffffffff);
-
-    unroll32([&in, &out, &pack_transform, d, &InReg, &OutReg, mask](auto i) {
-        constexpr int shift = (i * B) & 31;
-        InReg = LoadU(d, in);
-        in += 4;
-
-        InReg = pack_transform(InReg);
-
-        if constexpr (MASK) {
-            InReg = And(InReg, mask);
-        }
-
-        if constexpr (shift == 0) {
-            OutReg = InReg;
-        } else {
-            OutReg = Or(OutReg, ShiftLeft<shift>(InReg));
-        }
-
-        if constexpr (shift >= 32 - B) {
-            StoreU(OutReg, d, out);
-            out += 4;
-            if (shift > 32 - B) {
-                OutReg = ShiftRight<32 - shift>(InReg);
-            }
-        }
-    });
-}
-
-template <unsigned B, class F>
-void pack_mask(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, F &&pack_transform) {
-    pack<B, true, F>(in, out, std::forward<F>(pack_transform));
-}
+/** BP128_MAXBITS_DECL helps to declare bitpacking functions to detect maximum bitwidth with full
+ * unrolling
+ *
+ * @param FN_NAME (variable name) Name to use for the output function
+ * @param setup (code block) Code to run setup just prior to starting the bitpacking loop
+ * @param pack_transform (code block) Code block that applies transforms on `InReg` prior to
+ * bitpacking, re-assinging the result to the `InReg` variable
+ * @param ... Function signature. Must be at least: `const uint32_t *HWY_RESTRICT in`
+ *
+ */
+#define BP128_MAXBITS_DECL(FN_NAME, setup, pack_transform, ...)                                    \
+    uint32_t FN_NAME(__VA_ARGS__) {                                                                \
+        using namespace hwy::HWY_NAMESPACE;                                                        \
+        using D = Full128<uint32_t>;                                                               \
+        using Vec = Vec<D>;                                                                        \
+                                                                                                   \
+        D d;                                                                                       \
+        Vec accumulator = Zero(d);                                                                 \
+        setup;                                                                                     \
+        /* Rather than "max" operations, we can do bitwise or, since we just care about the        \
+         * highest set bit */                                                                      \
+                                                                                                   \
+        BP128_UNROLL_LOOP32(i, {                                                                   \
+            Vec InReg = LoadU(d, in);                                                              \
+            pack_transform;                                                                        \
+            accumulator = Or(accumulator, InReg);                                                  \
+            in += 4;                                                                               \
+        })                                                                                         \
+                                                                                                   \
+        /* Reduce Or across all lanes */                                                           \
+        const auto tmp1 = Or(ShiftRightLanes<2>(d, accumulator), accumulator);                     \
+        const auto tmp2 = Or(ShiftRightLanes<1>(d, tmp1), tmp1);                                   \
+        uint32_t val = GetLane(tmp2);                                                              \
+        return bits(val);                                                                          \
+    }
 
 // From
 // https://github.com/lemire/simdcomp/blob/dd9317ff7df8ad6350d492e6a54600a9a69e7919/src/simdcomputil.c#L16-L29
@@ -189,85 +263,6 @@ inline uint32_t bits(const uint32_t v) {
 #else
     return v == 0 ? 0 : 32 - __builtin_clz(v); /* assume GCC-like compiler if not microsoft */
 #endif
-}
-
-/**
- * @brief Calculate maximum bits needed to store a chunk of 128 numbers
- *
- * @tparam F
- * @param in
- * @param pack_transform
- * @return uint32_t
- */
-template <class F> uint32_t maxbits(const uint32_t *HWY_RESTRICT in, F &&pack_transform) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-
-    D d;
-    Vec accumulator = Zero(d);
-    // Rather than "max" operations, we can do bitwise or, since we just care about the highest set
-    // bit
-
-    unroll32([&in, &pack_transform, d, &accumulator](auto i) {
-        accumulator = Or(accumulator, pack_transform(LoadU(d, in)));
-        in += 4;
-    });
-
-    // Reduce Or across all lanes
-    const auto tmp1 = Or(ShiftRightLanes<2>(d, accumulator), accumulator);
-    const auto tmp2 = Or(ShiftRightLanes<1>(d, tmp1), tmp1);
-    uint32_t val = GetLane(tmp2);
-    return bits(val);
-}
-
-#define BP128_SWITCH_CASE(i, function, ...)                                                        \
-    case i:                                                                                        \
-        function<i>(__VA_ARGS__);                                                                  \
-        break;
-
-#define BP128_SWITCH_CASE4(start, function, ...)                                                   \
-    BP128_SWITCH_CASE((start + 0), function, __VA_ARGS__)                                          \
-    BP128_SWITCH_CASE((start + 1), function, __VA_ARGS__)                                          \
-    BP128_SWITCH_CASE((start + 2), function, __VA_ARGS__)                                          \
-    BP128_SWITCH_CASE((start + 3), function, __VA_ARGS__)
-
-#define BP128_SWITCH_CASE32(function, ...)                                                         \
-    BP128_SWITCH_CASE4(1, function, __VA_ARGS__)                                                   \
-    BP128_SWITCH_CASE4(5, function, __VA_ARGS__)                                                   \
-    BP128_SWITCH_CASE4(9, function, __VA_ARGS__)                                                   \
-    BP128_SWITCH_CASE4(13, function, __VA_ARGS__)                                                  \
-    BP128_SWITCH_CASE4(17, function, __VA_ARGS__)                                                  \
-    BP128_SWITCH_CASE4(21, function, __VA_ARGS__)                                                  \
-    BP128_SWITCH_CASE4(25, function, __VA_ARGS__)                                                  \
-    BP128_SWITCH_CASE4(29, function, __VA_ARGS__)
-
-// This overload allows runtime selection of number of bits
-template <class F>
-void pack_mask(
-    const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit,
-    F &&unpack_transform
-) {
-    switch (bit) { BP128_SWITCH_CASE32(pack_mask, in, out, unpack_transform) }
-}
-
-// This overload allows runtime selection of number of bits
-template <class F>
-void unpack(
-    const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit,
-    F &&unpack_transform
-) {
-    switch (bit) {
-    case 0:
-        unpack<0>(in, out, unpack_transform);
-        break;
-    
-    BP128_SWITCH_CASE32(unpack, in, out, unpack_transform)
-    }
 }
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE

--- a/r/src/bpcells-cpp/simd/bp128/bp128-helper-inl.h
+++ b/r/src/bpcells-cpp/simd/bp128/bp128-helper-inl.h
@@ -24,6 +24,16 @@ HWY_BEFORE_NAMESPACE();
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
 // ##############################################################################
+// #                           REFERENCE RESOURCES                              #
+// ##############################################################################
+// - Original BP-128 paper by Daniel Lemire: https://arxiv.org/pdf/1209.2137
+// - Check out pack128 and unpack128 from the tests in `test-bp128.cpp` for an easy-to-read implementation
+//   of the vanilla BP-128 logic
+// - Daniel Lemire repo with some of these functions implemented: https://github.com/lemire/simdcomp
+//    - A bit tough to read, but was an important reference for the original implementation
+
+
+// ##############################################################################
 // #                              HELPER MACROS                                 #
 // ##############################################################################
 

--- a/r/src/bpcells-cpp/simd/bp128/d1_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1_maxbits.cpp
@@ -33,6 +33,7 @@ BP128_MAXBITS_DECL(
     // Transform Code (InReg is the input data)
     {
         const auto tmp = InReg;
+        // Delta encode: InReg=[a,b,c,d]; prevOffset=[?,?,?,h]; Output [a-h, b-a, c-b, d-c]
         InReg = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
         prevOffset = tmp;
     },

--- a/r/src/bpcells-cpp/simd/bp128/d1_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1_maxbits.cpp
@@ -1,5 +1,5 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -25,19 +25,21 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-uint32_t maxbits_d1(uint32_t initvalue, const uint32_t *HWY_RESTRICT in) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
+BP128_MAXBITS_DECL(
+    maxbits_d1,
+    // Setup Code
     Vec prevOffset = Set(d, initvalue);
-    return maxbits(in, [d, &prevOffset](auto v) {
-        // Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
-        const auto res = Sub(v, CombineShiftRightLanes<3>(d, v, prevOffset));
-        prevOffset = v;
-        return res;
-    });
-}
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        const auto tmp = InReg;
+        InReg = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
+        prevOffset = tmp;
+    },
+    // Arguments
+    uint32_t initvalue,
+    const uint32_t *HWY_RESTRICT in
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/d1_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1_pack.cpp
@@ -1,5 +1,5 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -25,24 +25,25 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void pack_d1(
+BP128_PACK_DECL(
+    pack_d1,
+    // Setup Code
+    Vec prevOffset = Set(d, initvalue);
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        const auto tmp = InReg;
+        InReg = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
+        prevOffset = tmp;
+    },
+    // Call args in parens
+    (initvalue, in, out),
+    // Arguments
     uint32_t initvalue,
     const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
-    Vec prevOffset = Set(d, initvalue);
-    pack_mask(in, out, bit, [d, &prevOffset](auto v) {
-        // Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
-        const auto res = Sub(v, CombineShiftRightLanes<3>(d, v, prevOffset));
-        prevOffset = v;
-        return res;
-    });
-}
+    uint32_t *HWY_RESTRICT out
+)
+
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 
 HWY_AFTER_NAMESPACE();

--- a/r/src/bpcells-cpp/simd/bp128/d1_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1_pack.cpp
@@ -33,6 +33,7 @@ BP128_PACK_DECL(
     // Transform Code (InReg is the input data)
     {
         const auto tmp = InReg;
+        // Delta encode: InReg=[a,b,c,d]; prevOffset=[?,?,?,h]; Output [a-h, b-a, c-b, d-c]
         InReg = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
         prevOffset = tmp;
     },

--- a/r/src/bpcells-cpp/simd/bp128/d1z_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1z_maxbits.cpp
@@ -1,5 +1,5 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -25,27 +25,27 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-uint32_t maxbits_d1z(uint32_t initvalue, const uint32_t *HWY_RESTRICT in) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
-    Rebind<int32_t, D> d_signed;
-
+// Need to do this to prevent the comma from counting as a macro argument separator
+#define D_SIGNED_DECL Rebind<int32_t, D> d_signed
+BP128_MAXBITS_DECL(
+    maxbits_d1z,
+    // Setup Code
+    D_SIGNED_DECL;
     Vec prevOffset = Set(d, initvalue);
-    return maxbits(in, [d, d_signed, &prevOffset](auto v) {
+    ,
+    // Transform Code (InReg is the input data)
+    {
         // Delta encode: Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
-        const auto res = Sub(v, CombineShiftRightLanes<3>(d, v, prevOffset));
-
+        const auto tmp = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
         // Update offset for next iteration
-        prevOffset = v;
-
+        prevOffset = InReg;
         // Zigzag encode: (i >> 31) ^ (i << 1)    (arithmetic shift right here)
-        return Xor(
-            BitCast(d, ShiftRight<31>(BitCast(d_signed, res))), ShiftLeft<1>(res)
-        );
-    });
-}
+        InReg = Xor(BitCast(d, ShiftRight<31>(BitCast(d_signed, tmp))), ShiftLeft<1>(tmp));
+    },
+    // Arguments
+    uint32_t initvalue,
+    const uint32_t *HWY_RESTRICT in
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/d1z_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1z_maxbits.cpp
@@ -35,11 +35,12 @@ BP128_MAXBITS_DECL(
     ,
     // Transform Code (InReg is the input data)
     {
-        // Delta encode: Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
+        // Delta encode: InReg=[a,b,c,d]; prevOffset=[?,?,?,h]; Output [a-h, b-a, c-b, d-c]
         const auto tmp = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
         // Update offset for next iteration
         prevOffset = InReg;
         // Zigzag encode: (i >> 31) ^ (i << 1)    (arithmetic shift right here)
+        // See https://lemire.me/blog/2022/11/25/making-all-your-integers-positive-with-zigzag-encoding/
         InReg = Xor(BitCast(d, ShiftRight<31>(BitCast(d_signed, tmp))), ShiftLeft<1>(tmp));
     },
     // Arguments

--- a/r/src/bpcells-cpp/simd/bp128/d1z_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1z_pack.cpp
@@ -35,11 +35,12 @@ BP128_PACK_DECL(
     ,
     // Transform Code (InReg is the input data)
     {
-        // Delta encode: Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
+        // Delta encode: InReg=[a,b,c,d]; prevOffset=[?,?,?,h]; Output [a-h, b-a, c-b, d-c]
         const auto tmp = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
         // Update offset for next iteration
         prevOffset = InReg;
         // Zigzag encode: (i >> 31) ^ (i << 1)    (arithmetic shift right here)
+        // See https://lemire.me/blog/2022/11/25/making-all-your-integers-positive-with-zigzag-encoding/
         InReg = Xor(BitCast(d, ShiftRight<31>(BitCast(d_signed, tmp))), ShiftLeft<1>(tmp));
     },
     // Call args in parens

--- a/r/src/bpcells-cpp/simd/bp128/d1z_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1z_pack.cpp
@@ -1,5 +1,5 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -25,33 +25,30 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-
-void pack_d1z(
+// Need to do this to prevent the comma from counting as a macro argument separator
+#define D_SIGNED_DECL Rebind<int32_t, D> d_signed
+BP128_PACK_DECL(
+    pack_d1z,
+    // Setup Code
+    D_SIGNED_DECL;
+    Vec prevOffset = Set(d, initvalue);
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        // Delta encode: Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
+        const auto tmp = Sub(InReg, CombineShiftRightLanes<3>(d, InReg, prevOffset));
+        // Update offset for next iteration
+        prevOffset = InReg;
+        // Zigzag encode: (i >> 31) ^ (i << 1)    (arithmetic shift right here)
+        InReg = Xor(BitCast(d, ShiftRight<31>(BitCast(d_signed, tmp))), ShiftLeft<1>(tmp));
+    },
+    // Call args in parens
+    (initvalue, in, out),
+    // Arguments
     uint32_t initvalue,
     const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
-    Rebind<int32_t, D> d_signed;
-
-    Vec prevOffset = Set(d, initvalue);
-    pack_mask(in, out, bit, [d, d_signed, &prevOffset](auto v) {
-        // Delta encode: Input: [a,b,c,d]; [?,?,?,h]; Output [a-h, b-a, c-b, d-c]
-        const auto res = Sub(v, CombineShiftRightLanes<3>(d, v, prevOffset));
-
-        // Update offset for next iteration
-        prevOffset = v;
-
-        // Zigzag encode: (i >> 31) ^ (i << 1)    (arithmetic shift right here)
-        return Xor(
-            BitCast(d, ShiftRight<31>(BitCast(d_signed, res))), ShiftLeft<1>(res)
-        );
-    });
-}
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/d1z_unpack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1z_unpack.cpp
@@ -1,5 +1,5 @@
 // Copyright 2023 BPCells contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
@@ -25,38 +25,36 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void unpack_d1z(
-    uint32_t initvalue,
-    const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
-    Rebind<int32_t, D> d_signed;
-
+// Need to do this to prevent the comma from counting as a macro argument separator
+#define D_SIGNED_DECL Rebind<int32_t, D> d_signed
+BP128_UNPACK_DECL(
+    unpack_d1z,
+    // Setup Code
+    D_SIGNED_DECL;
     Vec prevOffset = Set(d, initvalue);
-    Vec one = Set(d, 1);
-    unpack(in, out, bit, [d, d_signed, &prevOffset, one](auto v) {
+    ,
+    // Transform Code (OutReg is the data)
+    {
         // Zigzag decode: (i >> 1) ^ -(i & 1)
-        v = Xor(
-            ShiftRight<1>(v), BitCast(d, Neg(BitCast(d_signed, And(v, one))))
-        );
+        OutReg =
+            Xor(ShiftRight<1>(OutReg), BitCast(d, Neg(BitCast(d_signed, And(OutReg, Set(d, 1))))));
 
         // OutReg = bitwise_xor(shift_r(OutReg, 1), sub(zero, bitwise_and(OutReg, one)));
         // Delta decode: Input: [a,b,c,d]; [?,?,?,h]; Output [a+h, a+b+h, a+b+c+h, a+b+c+d+h]
-        const auto tmp1 = Add(ShiftLeftLanes<2>(d, v), v);
+        const auto tmp1 = Add(ShiftLeftLanes<2>(d, OutReg), OutReg);
         const auto tmp2 = Add(ShiftLeftLanes<1>(d, tmp1), tmp1);
-        const auto res = Add(tmp2, BroadcastLane<3>(prevOffset));
+        OutReg = Add(tmp2, BroadcastLane<3>(prevOffset));
 
         // Update offset for next iteration
-        prevOffset = res;
-
-        return res;
-    });
-}
+        prevOffset = OutReg;
+    },
+    // Call args in parens
+    (initvalue, in, out),
+    // Arguments
+    uint32_t initvalue,
+    const uint32_t *HWY_RESTRICT in,
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/d1z_unpack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/d1z_unpack.cpp
@@ -36,6 +36,7 @@ BP128_UNPACK_DECL(
     // Transform Code (OutReg is the data)
     {
         // Zigzag decode: (i >> 1) ^ -(i & 1)
+        // See https://lemire.me/blog/2022/11/25/making-all-your-integers-positive-with-zigzag-encoding/
         OutReg =
             Xor(ShiftRight<1>(OutReg), BitCast(d, Neg(BitCast(d_signed, And(OutReg, Set(d, 1))))));
 

--- a/r/src/bpcells-cpp/simd/bp128/diff_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/diff_maxbits.cpp
@@ -25,16 +25,21 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-uint32_t maxbits_diff(const uint32_t *HWY_RESTRICT ref, const uint32_t *HWY_RESTRICT in) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    D d;
-    return maxbits(in, [&ref, d](auto v) {
-        v = Sub(v, LoadU(d, ref));
+
+BP128_MAXBITS_DECL(
+    maxbits_diff,
+    // Setup Code 
+    // (none)
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        InReg = Sub(InReg, LoadU(d, ref));
         ref += 4;
-        return v;
-    });
-}
+    },
+    // Arguments
+    const uint32_t *HWY_RESTRICT ref,
+    const uint32_t *HWY_RESTRICT in
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/diff_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/diff_pack.cpp
@@ -25,21 +25,23 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void pack_diff(
+BP128_PACK_DECL(
+    pack_diff,
+    // Setup Code
+    // (none)
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        InReg = Sub(InReg, LoadU(d, ref));
+        ref += 4;
+    },
+    // Call args in parens
+    (ref, in, out),
+    // Arguments
     const uint32_t *HWY_RESTRICT ref,
     const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    D d;
-    pack_mask(in, out, bit, [&ref, d](auto v) {
-        v = Sub(v, LoadU(d, ref));
-        ref += 4;
-        return v;
-    });
-}
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/diff_unpack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/diff_unpack.cpp
@@ -25,21 +25,24 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void unpack_diff(
+BP128_UNPACK_DECL(
+    unpack_diff,
+    // Setup Code
+    // (none)
+    ,
+    // Transform Code (OutReg is the data)
+    {
+        OutReg = Add(OutReg, LoadU(d, ref));
+        ref += 4;
+    },
+    // Call args in parens
+    (ref, in, out),
+    // Arguments
     const uint32_t *HWY_RESTRICT ref,
     const uint32_t *HWY_RESTRICT in,
-    uint32_t *HWY_RESTRICT out,
-    const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    D d;
-    unpack(in, out, bit, [&ref, d](auto v) {
-        v = Add(v, LoadU(d, ref));
-        ref += 4;
-        return v;
-    });
-}
+    uint32_t *HWY_RESTRICT out
+)
+
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 
 HWY_AFTER_NAMESPACE();

--- a/r/src/bpcells-cpp/simd/bp128/for_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/for_maxbits.cpp
@@ -25,15 +25,20 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-uint32_t maxbits_FOR(uint32_t offset, const uint32_t *HWY_RESTRICT in) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
-    Vec offset_v = Set(d, offset);
 
-    return maxbits(in, [offset_v](auto v) { return Sub(v, offset_v); });
-}
+BP128_MAXBITS_DECL(
+    maxbits_FOR,
+    // Setup Code
+    Vec offset_v = Set(d, offset);
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        InReg = Sub(InReg, offset_v);
+    },
+    // Arguments
+    uint32_t offset,
+    const uint32_t *HWY_RESTRICT in
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/for_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/for_pack.cpp
@@ -25,17 +25,23 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void pack_FOR(
-    uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
+BP128_PACK_DECL(
+    pack_FOR,
+    // Setup Code
     Vec offset_v = Set(d, offset);
+    ,
+    // Transform Code (InReg is the input data)
+    {
+        InReg = Sub(InReg, offset_v);
 
-    pack_mask(in, out, bit, [offset_v](auto v) { return Sub(v, offset_v); });
-}
+    },
+    // Call args in parens
+    (offset, in, out),
+    // Arguments
+    uint32_t offset,
+    const uint32_t *HWY_RESTRICT in,
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/for_unpack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/for_unpack.cpp
@@ -25,17 +25,22 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void unpack_FOR(
-    uint32_t offset, const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit
-) {
-    using namespace hwy::HWY_NAMESPACE;
-    using D = Full128<uint32_t>;
-    using Vec = Vec<D>;
-    D d;
+BP128_UNPACK_DECL(
+    unpack_FOR,
+    // Setup Code
     Vec offset_v = Set(d, offset);
-
-    unpack(in, out, bit, [offset_v](auto v) { return Add(v, offset_v); });
-}
+    ,
+    // Transform Code (OutReg is the data)
+    {
+        OutReg = Add(OutReg, offset_v);
+    },
+    // Call args in parens
+    (offset, in, out),
+    // Arguments
+    uint32_t offset,
+    const uint32_t *HWY_RESTRICT in,
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/vanilla_maxbits.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/vanilla_maxbits.cpp
@@ -25,9 +25,18 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-uint32_t maxbits_bp128(const uint32_t *HWY_RESTRICT in) {
-    return maxbits(in, [](auto v) { return v; });
-}
+
+BP128_MAXBITS_DECL(
+    maxbits_bp128,
+    // Setup Code
+    // (none)
+    ,
+    // Transform Code (InReg is the input data)
+    // (none)
+    ,
+    // Arguments
+    const uint32_t *HWY_RESTRICT in
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/vanilla_pack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/vanilla_pack.cpp
@@ -25,9 +25,20 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void pack_bp128(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit) {
-    pack_mask(in, out, bit, [](auto v) { return v; });
-}
+BP128_PACK_DECL(
+    pack_bp128,
+    // Setup Code
+    // (none)
+    ,
+    // Transform Code (InReg is the input data)
+    // (none)
+    ,
+    // Call args in parens
+    (in, out),
+    // Arguments
+    const uint32_t *HWY_RESTRICT in,
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 

--- a/r/src/bpcells-cpp/simd/bp128/vanilla_unpack.cpp
+++ b/r/src/bpcells-cpp/simd/bp128/vanilla_unpack.cpp
@@ -25,9 +25,20 @@ HWY_BEFORE_NAMESPACE();
 
 namespace BPCells::simd::bp128::HWY_NAMESPACE {
 
-void unpack_bp128(const uint32_t *HWY_RESTRICT in, uint32_t *HWY_RESTRICT out, const uint32_t bit) {
-    unpack(in, out, bit, [](auto v) { return v; });
-}
+BP128_UNPACK_DECL(
+    unpack_bp128,
+    // Setup Code
+    // (none)
+    ,
+    // Transform Code (OutReg is the data)
+    // (none)
+    ,
+    // Call args in parens
+    (in, out),
+    // Arguments
+    const uint32_t *HWY_RESTRICT in,
+    uint32_t *HWY_RESTRICT out
+)
 
 } // namespace BPCells::simd::bp128::HWY_NAMESPACE
 


### PR DESCRIPTION
When re-running some benchmarks, I observed 30-40% performance regressions for in-memory BP-128 compression relative to the pre-Gentech code (e.g. commit 91ed30). This turned out to be caused by the shift from macro-based code to C++ lambda-based code. For the BP-128 kernels, it is extremely important to avoid loops or function calls in the core pack/unpack function, but the lambda-based code was not properly inlining some of the lambdas.

This PR makes two important changes and one unimportant change that may be useful for the future.

**Important change 1:** Shift back to using pure C macros to construct the core BP-128 kernels. These are the `BP128_*_DECL` macros, which try to isolate the core bitpacking logic in one place so all the variants need only specify their arguments and the transform logic applied pre/post bitpacking. Due to it being macros rather than C++ lambdas it's very ugly, but this should be code that rarely (if ever) needs updating. The good news is that due to the use of macros there's no function calls or loops for the compiler to improperly leave in.

**Important change 2:** reducing unnecessary memory copies in the in-memory benchmarking code

As shown in the table below, switching back to a macro-based solution took the performance hit from 30-40% to 5-10%, then reducing the memory copies in the in-memory benchmark allowed substantial improvements.

Code source | read val (GB/s) | read idx (GB/s) | write val (GB/s) | write idx (GB/s)
-- | -- | -- | -- | --
pre-highway 91ed30 | 8.49 | 5.74 | 8.99 | 5.69
github main de87d45 | 5.35 | 3.29 | 5.75 | 4.13
add lambda->macro change | 7.27 | 5.06 | 8.20 | 5.11
also reduce benchmark copies | 12.18 | 7.65 | 9.46 | 5.72


**Unimportant change:** adding the `Nx128` wrapper functions, which basically allow packing/unpacking multiple 128-integer chunks with a single function call. This reduces the number of indirect function calls required and can result in some modest time savings due to amortizing the highway library's dynamic dispatch (to use the best version for the available hardware features). However, the remaining big bottleneck is extra memory copies due to the existing `UIntReader` and `UIntWriter` classes. So it seemed not worth it to integrate the `Nx128` functions into `BP128UIntReader/Writer` given that it would be tricky and just need to be redone when/if the existing interfaces are improved.

To measure these overheads, I did a bit of benchmarking with just the vanilla BP-128 codec (no transforms), which should be the most impacted by overheads. This compared the existing benchmark code to bypassing the `BP128UIntReader/Writer` classes and just calling the `BPCells::simd::bp128` bitpacking functions directly on the memory of the arrays.

Method | write (GB/s) | read (GB/s)
-- | -- | --
`BP128UIntReader/Writer` | 8.60 | 9.81
`[un]pack_Nx128()` | 14.1 | 11.9
loop `[un]pack()` BP-128 | 13.8 | 9.17



