### PR TITLE
[r] add automatic website building

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,8 +39,8 @@ jobs:
         Rscript .github/workflows/deploy-reference.R
     - name: Configure Git
       run: |
-        git config --global user.name "GitHub Action"
-        git config --global user.email "action@github.com"
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
     - name: Create new branch
       run: |
         git checkout -b update-docs-$(git rev-parse --short=6 ${{ github.sha }})

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,62 @@
+name: Build Docs and Create a PR with Docs Changes
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build_docs:
+    name: Build and Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # to ensure other branches are available for build
+    - name: Install system dependencies
+      run: sudo apt-get install -y libhdf5-dev git-restore-mtime
+    - name: Set r compilation options
+      run: bash -c 'echo -e "MAKEFLAGS=--jobs=3\nCXXFLAGS += -O1 -UNDEBUG" > "$GITHUB_WORKSPACE/Makevars.user" && echo "R_MAKEVARS_USER=$GITHUB_WORKSPACE/Makevars.user" >> "$GITHUB_ENV"'
+    - name: Setup R
+      uses: r-lib/actions/setup-r@v2
+    - name: Install R dependencies
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with: 
+        cache-version: 1
+        working-directory: 'r'
+        extra-packages: |
+            any::pkgdown
+            any::devtools
+            any::uwot
+            any::irlba
+            any::RcppHNSW
+            any::igraph
+            any::BiocManager
+            bioc::BSgenome.Hsapiens.UCSC.hg38
+            github::GreenleafLab/motifmatchr
+            github::GreenleafLab/chromVARmotifs
+    - name: Install BPCells
+      run: |
+        Rscript -e 'install.packages("r", repos=NULL, type="source")'
+    - name: Create git worktree with docs
+      run: |
+        git worktree add r/docs docs-html
+    - name: Build documentation
+      run: |
+        Rscript .github/workflows/deploy-reference.R FALSE
+    - name: Configure Git
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "action@github.com"
+    - name: Create new branch
+      run: |
+        git checkout -b update-docs-$(git rev-parse --short=6 ${{ github.sha }})
+        git add .
+        git commit -m "Update documentation for commit $(git rev-parse --short=6 ${{ github.sha }})"
+      working-directory: r/docs
+    - name: Push changes to new branch
+      run: git push origin update-docs-$(git rev-parse --short=6 ${{ github.sha }})
+    - name: Create Pull Request # use message with last commit
+      run: |
+        gh pr create --title "Update docs for commit: $(git log -n 1 --pretty=%B)" --body "$(git log -n 1 main)" --base docs-html --head update-docs-$(git rev-parse --short=6 ${{ github.sha }})
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         fetch-depth: 0 # to ensure other branches are available for build
     - name: Install system dependencies
-      run: sudo apt-get install -y libhdf5-dev git-restore-mtime
+      run: sudo apt-get install -y libhdf5-dev
     - name: Set r compilation options
       run: bash -c 'echo -e "MAKEFLAGS=--jobs=3\nCXXFLAGS += -O1 -UNDEBUG" > "$GITHUB_WORKSPACE/Makevars.user" && echo "R_MAKEVARS_USER=$GITHUB_WORKSPACE/Makevars.user" >> "$GITHUB_ENV"'
     - name: Setup R

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,10 +23,6 @@ jobs:
       with: 
         cache-version: 1
         working-directory: 'r'
-        extra-packages: |
-            bioc::BSgenome.Hsapiens.UCSC.hg38
-            github::GreenleafLab/motifmatchr
-            github::GreenleafLab/chromVARmotifs
         needs: website
     - name: Install BPCells
       run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         git checkout -b update-docs-$(git rev-parse --short=6 ${{ github.sha }})
         git add .
-        if git diff --cached --quiet; then echo "No changes to commit. Exiting."; exit 0; fi
+        if git diff --cached --quiet; then echo "No changes to commit. Exiting."; exit 1; fi
         git commit -m "Update documentation for commit $(git rev-parse --short=6 ${{ github.sha }})"
       working-directory: r/docs
     - name: Push changes to new branch

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -51,6 +51,6 @@ jobs:
       run: git push origin update-docs-$(git rev-parse --short=6 ${{ github.sha }})
     - name: Create Pull Request # use message with last commit
       run: |
-        gh pr create --title "Update docs for commit: $(git log -n 1 --pretty=%B)" --body "$(git log -n 1 main)" --base docs-html --head update-docs-$(git rev-parse --short=6 ${{ github.sha }})
+        gh pr create --title "Update docs for commit: $(git log -n 1 --pretty=%s)" --body "$(git log -n 1 main)" --base docs-html --head update-docs-$(git rev-parse --short=6 ${{ github.sha }})
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,16 +24,10 @@ jobs:
         cache-version: 1
         working-directory: 'r'
         extra-packages: |
-            any::pkgdown
-            any::devtools
-            any::uwot
-            any::irlba
-            any::RcppHNSW
-            any::igraph
-            any::BiocManager
             bioc::BSgenome.Hsapiens.UCSC.hg38
             github::GreenleafLab/motifmatchr
             github::GreenleafLab/chromVARmotifs
+        needs: website
     - name: Install BPCells
       run: |
         Rscript -e 'install.packages("r", repos=NULL, type="source")'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,7 @@ jobs:
       run: |
         git checkout -b update-docs-$(git rev-parse --short=6 ${{ github.sha }})
         git add .
+        if git diff --cached --quiet; then echo "No changes to commit. Exiting."; exit 0; fi
         git commit -m "Update documentation for commit $(git rev-parse --short=6 ${{ github.sha }})"
       working-directory: r/docs
     - name: Push changes to new branch

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,7 +36,7 @@ jobs:
         git worktree add r/docs docs-html
     - name: Build documentation
       run: |
-        Rscript .github/workflows/deploy-reference.R FALSE
+        Rscript .github/workflows/deploy-reference.R
     - name: Configure Git
       run: |
         git config --global user.name "GitHub Action"

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -37,8 +37,8 @@ jobs:
         Rscript -e 'pkgdown::build_site_github_pages("r")'
     - name: Configure Git
       run: |
-        git config --global user.name "GitHub Action"
-        git config --global user.email "action@github.com"
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
     - name: Create new branch
       run: |
         git checkout -b update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -1,0 +1,60 @@
+name: Manually Rebuild All Docs and Create a PR with Docs Changes
+on:
+    workflow_dispatch:
+jobs:
+  build_docs:
+    name: Build and Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # to ensure other branches are available for build
+    - name: Install system dependencies
+      run: sudo apt-get install -y libhdf5-dev git-restore-mtime
+    - name: Set r compilation options
+      run: bash -c 'echo -e "MAKEFLAGS=--jobs=3\nCXXFLAGS += -O1 -UNDEBUG" > "$GITHUB_WORKSPACE/Makevars.user" && echo "R_MAKEVARS_USER=$GITHUB_WORKSPACE/Makevars.user" >> "$GITHUB_ENV"'
+    - name: Setup R
+      uses: r-lib/actions/setup-r@v2
+    - name: Install R dependencies
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with: 
+        cache-version: 1
+        working-directory: 'r'
+        extra-packages: |
+            any::pkgdown
+            any::devtools
+            any::uwot
+            any::irlba
+            any::RcppHNSW
+            any::igraph
+            any::BiocManager
+            bioc::BSgenome.Hsapiens.UCSC.hg38
+            github::GreenleafLab/motifmatchr
+            github::GreenleafLab/chromVARmotifs
+    - name: Install BPCells
+      run: |
+        Rscript -e 'install.packages("r", repos=NULL, type="source")'
+    - name: Create git worktree with docs
+      run: |
+        git worktree add r/docs docs-html
+    - name: Build documentation
+      run: |
+        Rscript .github/workflows/deploy-reference.R TRUE
+    - name: Configure Git
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "action@github.com"
+    - name: Create new branch
+      run: |
+        git checkout -b update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
+        git add .
+        git commit -m "Rebuild documentation for commit $(git rev-parse --short=6 ${{ github.sha }})"
+      working-directory: r/docs
+    - name: Push changes to new branch
+      run: git push origin update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
+    - name: Create Pull Request # use message with last commit
+      run: |
+        gh pr create --title "Rebuild docs for commit: $(git log -n 1 --pretty=%B)" --body "$(git log -n 1 main)" --base docs-html --head update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         git checkout -b update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
         git add .
+        if git diff --cached --quiet; then echo "No changes to commit. Exiting."; exit 0; fi
         git commit -m "Rebuild documentation for commit $(git rev-parse --short=6 ${{ github.sha }})"
       working-directory: r/docs
     - name: Push changes to new branch

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         fetch-depth: 0 # to ensure other branches are available for build
     - name: Install system dependencies
-      run: sudo apt-get install -y libhdf5-dev git-restore-mtime
+      run: sudo apt-get install -y libhdf5-dev
     - name: Set r compilation options
       run: bash -c 'echo -e "MAKEFLAGS=--jobs=3\nCXXFLAGS += -O1 -UNDEBUG" > "$GITHUB_WORKSPACE/Makevars.user" && echo "R_MAKEVARS_USER=$GITHUB_WORKSPACE/Makevars.user" >> "$GITHUB_ENV"'
     - name: Setup R

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         git checkout -b update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
         git add .
-        if git diff --cached --quiet; then echo "No changes to commit. Exiting."; exit 0; fi
+        if git diff --cached --quiet; then echo "No changes to commit. Exiting."; exit 1; fi
         git commit -m "Rebuild documentation for commit $(git rev-parse --short=6 ${{ github.sha }})"
       working-directory: r/docs
     - name: Push changes to new branch

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -22,16 +22,10 @@ jobs:
         cache-version: 1
         working-directory: 'r'
         extra-packages: |
-            any::pkgdown
-            any::devtools
-            any::uwot
-            any::irlba
-            any::RcppHNSW
-            any::igraph
-            any::BiocManager
             bioc::BSgenome.Hsapiens.UCSC.hg38
             github::GreenleafLab/motifmatchr
             github::GreenleafLab/chromVARmotifs
+        needs: website
     - name: Install BPCells
       run: |
         Rscript -e 'install.packages("r", repos=NULL, type="source")'
@@ -40,7 +34,7 @@ jobs:
         git worktree add r/docs docs-html
     - name: Build documentation
       run: |
-        Rscript .github/workflows/deploy-reference.R TRUE
+        Rscript -e 'pkgdown::build_site_github_pages("r")'
     - name: Configure Git
       run: |
         git config --global user.name "GitHub Action"

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -49,6 +49,6 @@ jobs:
       run: git push origin update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
     - name: Create Pull Request # use message with last commit
       run: |
-        gh pr create --title "Rebuild docs for commit: $(git log -n 1 --pretty=%B)" --body "$(git log -n 1 main)" --base docs-html --head update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
+        gh pr create --title "Rebuild docs for commit: $(git log -n 1 --pretty=%s)" --body "$(git log -n 1 main)" --base docs-html --head update-docs-rebuild-$(git rev-parse --short=6 ${{ github.sha }})
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-full-website.yml
+++ b/.github/workflows/deploy-full-website.yml
@@ -21,10 +21,6 @@ jobs:
       with: 
         cache-version: 1
         working-directory: 'r'
-        extra-packages: |
-            bioc::BSgenome.Hsapiens.UCSC.hg38
-            github::GreenleafLab/motifmatchr
-            github::GreenleafLab/chromVARmotifs
         needs: website
     - name: Install BPCells
       run: |

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -11,6 +11,7 @@ build_selective_vignette_changes <- function() {
     vignettes_folder <- "r/vignettes/"
     # Get all changes in the last commit
     changed_files <- system("git diff --name-only HEAD~1", intern = TRUE)
+    pkgdown::build_articles_index('r')
     # split to only get files in r/vignettes and only get the Rmd files
     changed_vignettes <- changed_files[grepl(vignettes_folder, changed_files)]
     changed_vignettes <- changed_vignettes[grepl("\\.Rmd$", changed_vignettes)]

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -14,10 +14,10 @@ build_selective_vignette_changes <- function() {
     # split to only get files in r/vignettes and only get the Rmd files
     changed_vignettes <- changed_files[grepl(vignettes_folder, changed_files)]
     changed_vignettes <- changed_vignettes[grepl("\\.Rmd$", changed_vignettes)]
+    pkgdown::build_articles_index('r')
     for (vgn in changed_vignettes) {
       pkgdown::build_article(gsub("\\.Rmd$", "", gsub("r/vignettes/", "", vgn)), 'r')
     }
-    pkgdown::build_articles_index('r')
 }
 
 pkgdown::build_home('r')

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -1,3 +1,12 @@
+# Copyright 2024 BPCells contributors
+# 
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# This script is used to automatically update docs-html branch when updating main branch
 build_selective_vignette_changes <- function() {
     vignettes_folder <- "r/vignettes/"
     # Get all changes in the last commit
@@ -9,17 +18,12 @@ build_selective_vignette_changes <- function() {
       pkgdown::build_article(gsub("\\.Rmd$", "", gsub("r/vignettes/", "", vgn)), 'r')
     }
 }
-args = commandArgs(TRUE)
-# First argument is whether to rebuild the entire site.
-rebuild <- as.logical(args[1])
-if (rebuild) {
-  pkgdown::build_site_github_pages('r')
-} else {
-  pkgdown::build_reference('r')
-  build_selective_vignette_changes()
-  pkgdown::build_news('r')
-  pkgdown::build_sitemap('r')
-  pkgdown::build_redirects('r')
-  pkgdown::build_search('r')
-  pkgdown::build_home('r')
-}
+
+
+pkgdown::build_reference('r')
+build_selective_vignette_changes()
+pkgdown::build_news('r')
+pkgdown:::build_sitemap('r')
+pkgdown::build_redirects('r')
+pkgdown::build_search('r')
+pkgdown::build_home('r')

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -1,0 +1,21 @@
+build_selective_vignette_changes <- function() {
+    vignettes_folder <- "r/vignettes/"
+    # Get all changes in the last commit
+    changed_files <- system("git diff --name-only HEAD~1", intern = TRUE)
+    # split to only get files in r/vignettes
+    changed_vignettes <- changed_files[grepl(vignettes_folder, changed_files)]
+    for (vgn in changed_vignettes) {
+      pkgdown::build_article(gsub("\\.Rmd$", "", gsub("r/vignettes/", "", vgn)), 'r')
+    }
+}
+args = commandArgs(TRUE)
+# First argument is whether to rebuild the entire site.
+rebuild <- as.logical(args[1])
+if (rebuild) {
+  pkgdown::build_site_github_pages('r')
+} else {
+  pkgdown::build_reference('r')
+  build_selective_vignette_changes()
+  pkgdown::build_news('r')
+  pkgdown::build_home('r')
+}

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -20,11 +20,10 @@ build_selective_vignette_changes <- function() {
     }
 }
 
-
+pkgdown::build_home('r')
 pkgdown::build_reference('r')
 build_selective_vignette_changes()
 pkgdown::build_news('r')
 pkgdown:::build_sitemap('r')
 pkgdown::build_redirects('r')
 pkgdown::build_search('r')
-pkgdown::build_home('r')

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -11,13 +11,13 @@ build_selective_vignette_changes <- function() {
     vignettes_folder <- "r/vignettes/"
     # Get all changes in the last commit
     changed_files <- system("git diff --name-only HEAD~1", intern = TRUE)
-    pkgdown::build_articles_index('r')
     # split to only get files in r/vignettes and only get the Rmd files
     changed_vignettes <- changed_files[grepl(vignettes_folder, changed_files)]
     changed_vignettes <- changed_vignettes[grepl("\\.Rmd$", changed_vignettes)]
     for (vgn in changed_vignettes) {
       pkgdown::build_article(gsub("\\.Rmd$", "", gsub("r/vignettes/", "", vgn)), 'r')
     }
+    pkgdown::build_articles_index('r')
 }
 
 pkgdown::build_home('r')

--- a/.github/workflows/deploy-reference.R
+++ b/.github/workflows/deploy-reference.R
@@ -2,8 +2,9 @@ build_selective_vignette_changes <- function() {
     vignettes_folder <- "r/vignettes/"
     # Get all changes in the last commit
     changed_files <- system("git diff --name-only HEAD~1", intern = TRUE)
-    # split to only get files in r/vignettes
+    # split to only get files in r/vignettes and only get the Rmd files
     changed_vignettes <- changed_files[grepl(vignettes_folder, changed_files)]
+    changed_vignettes <- changed_vignettes[grepl("\\.Rmd$", changed_vignettes)]
     for (vgn in changed_vignettes) {
       pkgdown::build_article(gsub("\\.Rmd$", "", gsub("r/vignettes/", "", vgn)), 'r')
     }
@@ -17,5 +18,8 @@ if (rebuild) {
   pkgdown::build_reference('r')
   build_selective_vignette_changes()
   pkgdown::build_news('r')
+  pkgdown::build_sitemap('r')
+  pkgdown::build_redirects('r')
+  pkgdown::build_search('r')
   pkgdown::build_home('r')
 }

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -50,3 +50,6 @@ Suggests:
     igraph
 Depends: 
     R (>= 3.5.0)
+Config/Needs/website: pkgdown, devtools, uwot, irlba, RcppHNSW, igraph, BiocManager, 
+
+

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -50,4 +50,4 @@ Suggests:
     igraph
 Depends: 
     R (>= 3.5.0)
-Config/Needs/website: pkgdown, devtools, uwot, irlba, RcppHNSW, igraph, BiocManager
+Config/Needs/website: pkgdown, devtools, uwot, irlba, RcppHNSW, igraph, BiocManager, bioc::BSgenome.Hsapiens.UCSC.hg38, github::GreenleafLab/motifmatchr, github::GreenleafLab/chromVARmotifs

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -50,6 +50,4 @@ Suggests:
     igraph
 Depends: 
     R (>= 3.5.0)
-Config/Needs/website: pkgdown, devtools, uwot, irlba, RcppHNSW, igraph, BiocManager, 
-
-
+Config/Needs/website: pkgdown, devtools, uwot, irlba, RcppHNSW, igraph, BiocManager


### PR DESCRIPTION
Creates a PR to html-docs whenever something is pushed to `main`, and performs the website building workflow indicated in `Wiki/Tool Development Workflows`
Title of PR is `Update docs for commit: <most_recent_commit_message>`

Message of PR is the git log of the most recent commit.  I am open to changing this to something that better describes the changes to documentation.
Example of how this would look can be found [here](https://github.com/immanuelazn/BPCells/pull/17).  This PR was created as a result of pushing this commit into my personal BPCells main branch.


We can also make it perform an automatic push to `html-docs`, if that is preferred.  We can also set this up to be a manually triggered workflow.  