### PR TITLE
[r] Adjust default parameters for `cluster_graph_leiden()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -28,6 +28,7 @@ Contributions welcome :)
 - `trackplot_combine()` now has smarter layout logic for margins, as well as detecting when plots are being combined that cover different genomic regions. (pull request #116)
 - `select_cells()` and `select_chromosomes()` now also allow using a logical mask for selection. (pull request #117)
 - BPCells installation can now also be configured by setting the `LDFLAGS` or `CFLAGS` as environment variables in addition to setting them in `~/.R/Makevars` (pull request #124)
+- `cluster_graph_leiden()` now has better defaults that produce reasonable cluster counts regardless of dataset size. (pull request #147) 
 
 ## Bug-fixes
 - Fixed error message when a matrix is too large to be converted to dgCMatrix. (Thanks to @RookieA1 for reporting issue #95)

--- a/r/man/cluster.Rd
+++ b/r/man/cluster.Rd
@@ -6,16 +6,25 @@
 \alias{cluster_graph_seurat}
 \title{Cluster an adjacency matrix}
 \usage{
-cluster_graph_leiden(snn, resolution = 0.001, seed = 12531, ...)
+cluster_graph_leiden(
+  snn,
+  resolution = 1,
+  objective_function = c("modularity", "CPM"),
+  seed = 12531,
+  ...
+)
 
 cluster_graph_louvain(snn, resolution = 1, seed = 12531)
 
 cluster_graph_seurat(snn, resolution = 0.8, ...)
 }
 \arguments{
-\item{snn}{Symmetric adjacency matrix (dgCMatrix) output from e.g. knn_to_snn_graph. Only the lower triangle is used}
+\item{snn}{Symmetric adjacency matrix (dgCMatrix) output from e.g. \code{knn_to_snn_graph()} or \code{knn_to_geodesic_graph()}. Only the lower triangle is used}
 
 \item{resolution}{Resolution parameter. Higher values result in more clusters}
+
+\item{objective_function}{Graph statistic to optimize during clustering. Modularity is the default as it keeps resolution independent of dataset size (see details below).
+For the meaning of each option, see \code{igraph::cluster_leiden()}.}
 
 \item{seed}{Random seed for clustering initialization}
 
@@ -28,7 +37,10 @@ Factor vector containing the cluster assignment for each cell.
 Cluster an adjacency matrix
 }
 \details{
-\strong{cluster_graph_leiden}: Leiden graph clustering algorithm \code{igraph::cluster_leiden()}
+\strong{cluster_graph_leiden}: Leiden clustering algorithm \code{igraph::cluster_leiden()}.
+Note that when using \code{objective_function = "CPM"} the number of clusters empirically scales with \code{cells * resolution},
+so 1e-3 is a good resolution for 10k cells, but 1M cells is better with a 1e-5 resolution. A resolution of 1 is a
+good default when \code{objective_function = "modularity"} per the default.
 
 \strong{cluster_graph_louvain}: Louvain graph clustering algorithm \code{igraph::cluster_louvain()}
 

--- a/r/tests/testthat/test-clustering.R
+++ b/r/tests/testthat/test-clustering.R
@@ -1,0 +1,67 @@
+# Copyright 2024 BPCells contributors
+# 
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+test_that("C++ SNN calculation works",{
+    
+    k <- 10
+
+    for (cells in c(100, 1000)) {
+        neighbor_sim <- matrix(sample.int(cells, cells*k, replace=TRUE), nrow=cells)
+
+        # Make sure no cell is listed twice as a nearest neighbor
+        for (i in seq_len(cells)) {
+            while (length(unique(neighbor_sim[i,])) != k) {
+                neighbor_sim[i,] <- sample.int(cells, k)
+            }
+        }
+
+        min_val <- 1/15
+        snn <- knn_to_snn_graph(list(idx=neighbor_sim), min_val=min_val, self_loops=TRUE)
+
+        mat <- knn_to_graph(list(idx=neighbor_sim), use_weights=FALSE)
+
+        mat <- mat %*% t(mat)
+        mat <- mat / (2 * k - mat)
+        mat@x[mat@x < min_val] <- 0
+        # Prune the explicit 0 entries from storage
+        mat <- Matrix::drop0(mat) 
+        mat <- Matrix::tril(mat)
+        expect_identical(
+            snn,
+            as(mat, "dgCMatrix")
+        )
+        snn2 <- knn_to_snn_graph(list(idx=neighbor_sim), min_val=min_val, self_loops=FALSE)
+        diag(mat) <- 0
+        mat <- Matrix::drop0(mat)
+        expect_identical(
+            snn2,
+            as(mat, "dgCMatrix")
+        )
+    }
+
+})
+
+test_that("C++ UMAP graph calculation works", {
+    # This uses a pre-calculated graph from the umap-learn python package.
+    # See ../data/generate_iris_geodesic_graph.R for the generation code 
+    test_data <- readRDS("../data/iris_geodesic_graph.rds")
+    knn <- test_data$knn
+    res <- knn_to_geodesic_graph(knn)
+    expect_equal(as.matrix(res + t(res)), as.matrix(test_data$graph), tolerance=1e-6)
+})
+
+test_that("igraph clustering doesn't crash", {
+    skip_if_not_installed("igraph")
+    test_data <- readRDS("../data/iris_geodesic_graph.rds")
+    knn <- test_data$knn
+    graph <- knn_to_geodesic_graph(knn)
+
+    expect_no_condition(cluster_graph_leiden(graph))
+    expect_no_condition(cluster_graph_leiden(graph, objective_function="CPM"))
+    expect_no_condition(cluster_graph_louvain(graph))
+})


### PR DESCRIPTION
Currently, `cluster_graph_leiden()` by default will output a number of clusters that scales approximately linearly with number of cells if the `resolution` parameter is held constant. This is generally not good and leads to problems like [this](https://github.com/bnprks/BPCells/issues/125#issuecomment-2359162884) where people get thousands of clusters called on large datasets.

This pull request does the following:
- Changes default `objective_function` from `CPM` to `modularity` sets default `resolution` back to 1.
- Moves clustering-related tests to a new file and makes a basic test to confirm that the clustering functions at least don't crash. I don't know of a good way of validating the clustering is working, so not crashing seems good enough for now.

Here is the benchmarking data to justify this change. Note that Leiden modularity with resolution = 1 gives consistent cluster sizes just like Louvain, but Leiden CPM will give out a ton of clusters for large datasets unless the resolution parameter is adjusted down for large datasets.

![resolution_plot](https://github.com/user-attachments/assets/53a6d1de-b9b4-486c-b9a2-17b8525dc161)

[cluster-resolution.csv](https://github.com/user-attachments/files/17516416/cluster-resolution.csv)

<details>
<summary> Click for plotting code </summary>

```r
data |>
  mutate(alg=case_match(alg, "leiden" ~ "Leiden CPM", "leiden-modularity" ~ "Leiden Modularity", "louvain" ~ "Louvain"),
         resolution=factor(as.numeric(resolution), sort(unique(as.numeric(resolution))))) |>
  ggplot(aes(cells, clusts, color=resolution)) +
  geom_line() +
  geom_point() +
  scale_x_continuous(transform="log10", guide=guide_axis_logticks(), labels=scales::label_log(), breaks=c(1e5, 1e6)) +
  scale_y_continuous(transform="log10", guide=guide_axis_logticks()) +
  scale_color_manual(values=RColorBrewer::brewer.pal(9, "BuPu")[3:9]) +
  facet_wrap("alg") +
  theme_bw() + 
  coord_fixed() +
  labs(title="Cluster counts by resolution", y="Cluster count", x="Dataset size (cells)")
```
</details>