### PR TITLE
[r] Fix awk typo in configure error message

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -92,7 +92,7 @@ if [ -z $HDF5_OK ]; then
         HDF5_LIBS="$HDF5_LIBS -lhdf5"
         $CC tools/h5write.c $CFLAGS $LDFLAGS $HDF5_CFLAGS $HDF5_LIBS -o tools/h5write 2>&3 && HDF5_OK="yes";
     else
-        echo "Failure running either 'h5cc -show' or: 'h5cc -showconfig | awk -F: '/FLAGS|Extra libraries:/ {printf("%s ", \$2)}'"
+        echo "Failure running either 'h5cc -show' or: 'h5cc -showconfig | awk -F: '/FLAGS|Extra libraries:/ {printf(\"%s \", \$2)}'"
     fi
 fi
 


### PR DESCRIPTION
This is to address some confusion that popped up in #149, where the error message didn't print out the quotation marks from the original command correctly