### PR TITLE
[r] Fix leiden tests in CI

### DIFF
--- a/r/tests/testthat/test-clustering.R
+++ b/r/tests/testthat/test-clustering.R
@@ -61,7 +61,16 @@ test_that("igraph clustering doesn't crash", {
     knn <- test_data$knn
     graph <- knn_to_geodesic_graph(knn)
 
-    expect_no_condition(cluster_graph_leiden(graph))
-    expect_no_condition(cluster_graph_leiden(graph, objective_function="CPM"))
+    # The `resolution_parameter` param in igraph `cluster_leiden()` is deprecated,
+    # causing `expect_no_condition()` to fail. This workaround avoids test failures from 
+    # the deprecation warning, but is confirmed to fail if a call to `warning()` or `stop()` is
+    # inserted into `cluster_graph_leiden()`
+    suppressWarnings({
+        expect_no_warning(cluster_graph_leiden(graph))
+        expect_no_warning(cluster_graph_leiden(graph, objective_function="CPM"))
+        expect_no_error(cluster_graph_leiden(graph))
+        expect_no_error(cluster_graph_leiden(graph, objective_function="CPM"))
+    })
+
     expect_no_condition(cluster_graph_louvain(graph))
 })


### PR DESCRIPTION
This fixes leiden tests that succeeded with `devtools::test()` but fail under `testthat::test_dir()` used in CI.

The soft deprecation warning only showed up in CI, so I've adjusted the tests to not fail when encountering the soft deprecation warning.

The reason not to change the underlying code is that igraph only introduced the new parameter name 4 months ago ([link](https://github.com/igraph/rigraph/commit/f3cf6059bc4a90708f23e3df3d7d0adaa026260f)), and I don't want to force people to upgrade igraph that quickly in order to use BPCells. We can address the underlying deprecation later once there has been a bit more time for people to upgrade their igraph.