### PR TITLE
[r] Fix type confusion in `pseudobulk_matrix()` and clean up `parallel_split()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -41,6 +41,7 @@ Contributions welcome :)
 - Fixed discrepancy between default ArchR and BPCells peak calling insertion method, where BPCells defaulted to only using the start of each fragment as opposed to ArchR's method of using both start and end sites of fragments (pull request #143)
 - Fix error in `tile_matrix()` with fragment mode (pull request #141)
 - Fix precision bug in `sctransform_pearson()` on ARM architecture (pull request #141) 
+- Fix type-confusion error when `pseudobulk_matrix()` gets an integer matrix (pull request #174)
 
 ## Deprecations
 - `trackplot_coverage()` `legend_label` argument is now ignored, as the color legend is no longer shown by default for coverage plots.

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -1378,6 +1378,10 @@ parallel_split <- function(mat, threads, chunks=threads) {
   assert_is_wholenumber(chunks)
   assert_true(chunks >= threads)
 
+  if (threads <= 1L) {
+    return(mat)
+  }
+
   if (mat@transpose) {
     return(t(parallel_split(t(mat), threads, chunks)))
   }

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -2787,14 +2787,10 @@ matrix_stats <- function(matrix,
   row_stats_number <- match(row_stats, stat_options) - 1
   col_stats_number <- match(col_stats, stat_options) - 1
 
-  matrix <- convert_matrix_type(matrix, "double")
-  if (threads == 0L) {
-    it <- iterate_matrix(matrix)
-  } else {
-    it <- iterate_matrix(
-      parallel_split(matrix, threads, threads*4)
-    )
-  }
+  it <- matrix %>%
+    convert_matrix_type("double") %>%
+    parallel_split(threads, threads*4) %>%
+    iterate_matrix()
   res <- matrix_stats_cpp(it, row_stats_number, col_stats_number)
   rownames(res$row_stats) <- stat_options[seq_len(row_stats_number) + 1]
   rownames(res$col_stats) <- stat_options[seq_len(col_stats_number) + 1]
@@ -2851,14 +2847,10 @@ svds.IterableMatrix <- function(A, k, nu = k, nv = k, opts = list(), threads=0, 
   )
   solver_params[names(opts)] <- opts
 
-  A <- convert_matrix_type(A, "double")
-  if (threads == 0L) {
-    it <- iterate_matrix(A)
-  } else {
-    it <- iterate_matrix(
-      parallel_split(A, threads, threads*4)
-    )
-  }
+  it <- A %>%
+    convert_matrix_type("double") %>%
+    parallel_split(threads, threads*4) %>%
+    iterate_matrix()
   
   svds_cpp(
     it, 

--- a/r/tests/testthat/test-singlecell_utils.R
+++ b/r/tests/testthat/test-singlecell_utils.R
@@ -97,7 +97,8 @@ test_that("Pseudobulk aggregation works", {
   m0 <- as.matrix(m0)
   m0_t <- t(m0)
   m1_t <- t(m1)
-  for (matrices in list(list(m0_t, m1_t), list(m0, m1))) {
+  m1_int <- convert_matrix_type(m1, "uint32_t")
+  for (matrices in list(list(m0_t, m1_t), list(m0, m1), list(m0, m1_int))) {
     # Check across two equal groups, one group, and groups of equal length
     m <- matrices[[1]]
     m_bpcells <- matrices[[2]]


### PR DESCRIPTION
As reported in #173, `pseudobulk_matrix()` assumes that all input matrices are type "double", which results in type confusion in some circumstances. While fixing this, I also noticed an issue in `pseudobulk_matrix`'s use of `parallel_split`, which would needlessly split up a matrix even if no parallelism was requested (slight potential performance/memory hit). I did a small refactor to make `parallel_split` easier to use correctly and resolve the issue in `pseudobulk_matrix`

Changes in this PR:
- Always cast inputs to `pseudobulk_matrix()` to type `double`
- Adjust `parallel_split` logic to not do any splitting if `threads <= 1`
- Adjust other usages of `parallel_split` to take advantage of not needing the conditional logic anymore
