### PR TITLE
[cpp] Improve stats calculation in row/col reorder

### DIFF
--- a/r/tests/testthat/test-matrix_utils.R
+++ b/r/tests/testthat/test-matrix_utils.R
@@ -616,6 +616,7 @@ test_that("rbind Math works", {
   row_permute <- sample.int(nrow(m1))
   col_permute <- sample.int(ncol(m1))
   test_dense_multiply_ops(m1[row_permute, col_permute], i1[row_permute, col_permute])
+  test_rowsum_colsum_rowmean_colmean_rowvar_colvar(m1[row_permute, col_permute], i1[row_permute, col_permute])
 
   i1 <- set_threads(i1, 3)
   test_dense_multiply_ops(m1, i1)
@@ -637,6 +638,7 @@ test_that("cbind Math works", {
   row_permute <- sample.int(nrow(m1))
   col_permute <- sample.int(ncol(m1))
   test_dense_multiply_ops(m1[row_permute, col_permute], i1[row_permute, col_permute])
+  test_rowsum_colsum_rowmean_colmean_rowvar_colvar(m1[row_permute, col_permute], i1[row_permute, col_permute])
 
   i1 <- set_threads(i1, 3)
   test_dense_multiply_ops(m1, i1)


### PR DESCRIPTION
Motivation: The subset assignment operator results in a concatenation layer followed by a re-ordering of the rows/cols. We don't want this outer re-order layer to prevent any parallelism or other optimizations available on the inner layers, so it's time to have all the stats specialized for row/col re-ordering.

This just adds specializations for `computeMatrixStats`, `rowSums`, and `colSums` along with tests