### PR TITLE
[r] provide more mat input flex to `matrix_stats()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -11,6 +11,9 @@ Contributions welcome :)
 ## Features
 - Add `write_matrix_anndata_hdf5_dense()` which allows writing matrices in AnnData's dense format, most commonly used for `obsm` or `varm` matrices. (Thanks to @ycli1995 for pull request #166)
 
+## Improvements
+- `matrix_stats()` now also works with types `matrix` and `dgCMatrix`. (pull request #190)
+
 ## Bug-fixes
 - Fix error message printing when MACS crashes during `call_peaks_macs()` (pull request #175) 
 

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -2751,7 +2751,7 @@ setAs("IterableMatrix", "dgCMatrix", function(from) {
   }
 })
 
-# Add conversion to base R dense matrices
+# Add conversion to and from base R dense matrices
 setAs("IterableMatrix", "matrix", function(from) {
   rlang::inform(c(
       "Warning: Converting to a dense matrix may use excessive memory"
@@ -2764,6 +2764,8 @@ setAs("IterableMatrix", "matrix", function(from) {
   }
   mat
 })
+
+setAs("matrix", "IterableMatrix", function(from) mat <- as(as(from, "dgCMatrix"), "IterableMatrix"))
 
 matrix_to_integer <- function(matrix) { # a numeric matrix
     if (is.integer(matrix)) return(matrix) # styler: off
@@ -2803,7 +2805,7 @@ matrix_stats <- function(matrix,
                          col_stats = c("none", "nonzero", "mean", "variance"),
                          threads = 0L
                          ) {
-  assert_is(matrix, "IterableMatrix")
+  if (!is(matrix, "IterableMatrix")) tryCatch(matrix <- as(matrix, "IterableMatrix"), error = function(e) stop("Input matrix must be an IterableMatrix object"))
   assert_is_wholenumber(threads)
 
   stat_options <- c("none", "nonzero", "mean", "variance")

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -2689,6 +2689,7 @@ convert_matrix_type <- function(matrix, type = c("uint32_t", "double", "float"))
 #' 
 #' # Convert to BPCells from R
 #' as(dgc_mat, "IterableMatrix")
+#' as(base_r_mat, "IterableMatrix")
 #' @name matrix_R_conversion
 NULL
 
@@ -2805,7 +2806,13 @@ matrix_stats <- function(matrix,
                          col_stats = c("none", "nonzero", "mean", "variance"),
                          threads = 0L
                          ) {
-  if (!is(matrix, "IterableMatrix")) tryCatch(matrix <- as(matrix, "IterableMatrix"), error = function(e) stop("Input matrix must be an IterableMatrix object"))
+  if (!is(matrix, "IterableMatrix")) {
+    if (canCoerce(matrix, "IterableMatrix")) {
+      matrix <- as(matrix, "IterableMatrix")
+    } else {
+      rlang::abort("Input matrix cannot be converted to an IterableMatrix object")
+    }
+  }
   assert_is_wholenumber(threads)
 
   stat_options <- c("none", "nonzero", "mean", "variance")

--- a/r/man/matrix_R_conversion.Rd
+++ b/r/man/matrix_R_conversion.Rd
@@ -10,6 +10,7 @@ as.matrix(bpcells_mat) # Dense matrix conversion
 
 # Convert to BPCells from R
 as(dgc_mat, "IterableMatrix")
+as(base_r_mat, "IterableMatrix")
 }
 \description{
 BPCells matrices can be interconverted with Matrix package

--- a/r/tests/testthat/test-matrix_stats.R
+++ b/r/tests/testthat/test-matrix_stats.R
@@ -43,6 +43,8 @@ test_that("MatrixStats basic test", {
   stats1 <- matrix_stats(i1, "variance", "variance")
   stats2 <- matrix_stats(i2, "variance", "variance")
 
+  expect_error(matrix_stats(list("a"), "variance"), "cannot be converted to an IterableMatrix object")
+
   expect_identical(stats_m1_dgc, stats_m1)
   expect_identical(stats_m1_dgc, stats1)
 

--- a/r/tests/testthat/test-matrix_stats.R
+++ b/r/tests/testthat/test-matrix_stats.R
@@ -37,9 +37,14 @@ test_that("MatrixStats basic test", {
   i1 <- as(m1, "IterableMatrix")
   i2 <- t(i1)
 
-
+  
+  stats_m1 <- matrix_stats(as.matrix(m1), "variance", "variance")
+  stats_m1_dgc <- matrix_stats(m1, "variance", "variance")
   stats1 <- matrix_stats(i1, "variance", "variance")
   stats2 <- matrix_stats(i2, "variance", "variance")
+
+  expect_identical(stats_m1_dgc, stats_m1)
+  expect_identical(stats_m1_dgc, stats1)
 
   expect_identical(c("nonzero", "mean", "variance"), rownames(stats1$row_stats))
   expect_identical(c("nonzero", "mean", "variance"), rownames(stats1$col_stats))


### PR DESCRIPTION
Pretty self explanatory, added a few lines to allow matrix_stats, to be a little more input matrix agnostic.  I thought it would be better for us to automatically try to convert with a try, except block.  This should allow downstream caller functions to also work with `matrix` and `dgcMatrix`.

Also added a small helper conversion between `matrix` and `IterableMatrix`.