### PR TITLE
Ia/examples matrix ops

### DIFF
--- a/r/R/matrix-svds-docs.R
+++ b/r/R/matrix-svds-docs.R
@@ -69,10 +69,15 @@
 #' rownames(mat) <- paste0("gene", seq_len(50))
 #' colnames(mat) <- paste0("cell", seq_len(10))
 #' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
+#' 
 #' svd_res <- svds(mat, k = 5)
+#' 
 #' names(svd_res)
+#' 
 #' svd_res$d
+#' 
 #' dim(svd_res$u)
+#' 
 #' dim(svd_res$v)
 #' # Can also pass in values directly into RSpectra::svds
 #' svd_res <- svds(mat, k = 5, opts=c(maxitr = 500))

--- a/r/R/matrix-svds-docs.R
+++ b/r/R/matrix-svds-docs.R
@@ -64,5 +64,17 @@
 #' }
 #' @references Qiu Y, Mei J (2022). _RSpectra: Solvers for Large-Scale Eigenvalue and SVD Problems_. R package version 0.16-1, <https://CRAN.R-project.org/package=RSpectra>.
 #' @usage svds(A, k, nu = k, nv = k, opts = list(), threads=0L, ...)
+#' @examples
+#' mat <- matrix(rnorm(500), nrow = 50, ncol = 10)
+#' rownames(mat) <- paste0("gene", seq_len(50))
+#' colnames(mat) <- paste0("cell", seq_len(10))
+#' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
+#' svd_res <- svds(mat, k = 5)
+#' names(svd_res)
+#' svd_res$d
+#' dim(svd_res$u)
+#' dim(svd_res$v)
+#' # Can also pass in values directly into RSpectra::svds
+#' svd_res <- svds(mat, k = 5, opts=c(maxitr = 500))
 #' @name svds
 NULL

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -1546,10 +1546,12 @@ setMethod("iterate_matrix", "UnpackedMatrixMem_double", function(x) {
 #' colnames(mat) <- paste0("cell", seq_len(5))
 #' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
 #' mat
-#' # A regular transpose operation switches a user's rows and cols 
+#' 
+#' ## A regular transpose operation switches a user's rows and cols 
 #' t(mat)
-#' # Running `transpose_storage_order()` instead changes whether the storage is in row-major or col-major,
-#' # but does not switch the rows and cols
+#' 
+#' ## Running `transpose_storage_order()` instead changes whether the storage is in row-major or col-major,
+#' ## but does not switch the rows and cols
 #' transpose_storage_order(mat)
 #' @export
 transpose_storage_order <- function(matrix, outdir = tempfile("transpose"), tmpdir = tempdir(), load_bytes = 4194304L, sort_bytes = 1073741824L) {
@@ -2821,15 +2823,15 @@ setMethod("as.matrix", signature(x = "IterableMatrix"), function(x, ...) as(x, "
 #' colnames(mat) <- paste0("cell", 1:10)
 #' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
 #' 
-#' # 1. By default, no row or column stats are calculated
+#' ## By default, no row or column stats are calculated
 #' res_none <- matrix_stats(mat)
 #' res_none
 #' 
-#' # 2. Request row variance (automatically computes mean and nonzero too)
+#' ## Request row variance (automatically computes mean and nonzero too)
 #' res_row_var <- matrix_stats(mat, row_stats = "variance")
 #' res_row_var
 #' 
-#' # 3. Request both row variance and column variance
+#' ## Request both row variance and column variance
 #' res_both_var <- matrix_stats(
 #'   mat = mat,
 #'   row_stats = "variance",

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -1540,6 +1540,17 @@ setMethod("iterate_matrix", "UnpackedMatrixMem_double", function(x) {
 #' passes through the data, and ~7.3TB of data to be sorted in three passes
 #' through the data.
 #' @return MatrixDir object with a copy of the input matrix, but the storage order flipped
+#' @examples
+#' mat <- matrix(rnorm(50), nrow = 10, ncol = 5)
+#' rownames(mat) <- paste0("gene", seq_len(10))
+#' colnames(mat) <- paste0("cell", seq_len(5))
+#' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
+#' mat
+#' # A regular transpose operation switches a user's rows and cols 
+#' t(mat)
+#' # Running `transpose_storage_order()` instead changes whether the storage is in row-major or col-major,
+#' # but does not switch the rows and cols
+#' transpose_storage_order(mat)
 #' @export
 transpose_storage_order <- function(matrix, outdir = tempfile("transpose"), tmpdir = tempdir(), load_bytes = 4194304L, sort_bytes = 1073741824L) {
   assert_true(matrix_type(matrix) %in% c("uint32_t", "float", "double"))
@@ -2649,6 +2660,13 @@ setMethod("[", "ConvertMatrixType", function(x, i, j, ...) {
 #' @param type One of uint32_t (unsigned 32-bit integer), float (32-bit real number),
 #'   or double (64-bit real number)
 #' @return IterableMatrix object
+#' @examples
+#' mat <- matrix(rnorm(500), nrow = 50, ncol = 10)
+#' rownames(mat) <- paste0("gene", seq_len(10))
+#' colnames(mat) <- paste0("cell", seq_len(5))
+#' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
+#' mat
+#' convert_matrix_type(mat, "float")
 #' @export
 convert_matrix_type <- function(matrix, type = c("uint32_t", "double", "float")) {
   assert_is(matrix, c("dgCMatrix", "IterableMatrix"))
@@ -2797,6 +2815,27 @@ setMethod("as.matrix", signature(x = "IterableMatrix"), function(x, ...) as(x, "
 #' less complex stats are calculated in the process of calculating a more complicated stat.
 #' So to calculate mean and variance simultaneously, just ask for variance,
 #' which will compute mean and nonzero counts as a side-effect
+#' @examples
+#' mat <- matrix(rpois(100, lambda = 5), nrow = 10)
+#' rownames(mat) <- paste0("gene", 1:10)
+#' colnames(mat) <- paste0("cell", 1:10)
+#' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
+#' 
+#' # 1. By default, no row or column stats are calculated
+#' res_none <- matrix_stats(mat)
+#' res_none
+#' 
+#' # 2. Request row variance (automatically computes mean and nonzero too)
+#' res_row_var <- matrix_stats(mat, row_stats = "variance")
+#' res_row_var
+#' 
+#' # 3. Request both row variance and column variance
+#' res_both_var <- matrix_stats(
+#'   mat = mat,
+#'   row_stats = "variance",
+#'   col_stats = "mean"
+#' )
+#' res_both_var
 #' @export
 matrix_stats <- function(matrix,
                          row_stats = c("none", "nonzero", "mean", "variance"),

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -2990,6 +2990,30 @@ checksum <- function(matrix) {
 #' @seealso For an interface more similar to `base::apply`, see the [BPCellsArray](https://github.com/Yunuuuu/BPCellsArray/)
 #' project. For calculating colMeans on a sparse single cell RNA matrix it is about 8x slower than `apply_by_col`, due to the
 #' `base::apply` interface not being sparsity-aware. (See [pull request #104](https://github.com/bnprks/BPCells/pull/104) for benchmarking.)
+#' @examples
+#' mat <- matrix(rbinom(40, 1, 0.5) * sample.int(5, 40, replace = TRUE), nrow = 4)
+#' rownames(mat) <- paste0("gene", 1:4)
+#' mat
+#' 
+#' mat <- mat %>% as("IterableMatrix")
+#' 
+#' ## apply_by_row() example
+#' ## Get mean of every row
+#' 
+#' ## expect an error in the case that col-major matrix is passed
+#' apply_by_row(mat, function(val, row, col) {sum(val) / nrow(mat)}) %>% 
+#'  unlist()
+#' 
+#' ## Need to transpose matrix to make sure it is in row-order
+#' mat_row_order <- transpose_storage_order(mat)
+#' 
+#' ## works as expected for row major
+#' apply_by_row(mat_row_order, 
+#'  function(val, row, col) sum(val) / ncol(mat_row_order)
+#' ) %>% unlist()
+#' 
+#' # Also analogous to running rowMeans()
+#' rowMeans(mat)
 #' @export
 apply_by_row <- function(mat, fun, ...) {
   assert_is(mat, "IterableMatrix")
@@ -3006,6 +3030,13 @@ apply_by_row <- function(mat, fun, ...) {
 
 #' @return **apply_by_col** - A list of length `ncol(matrix)` with the results returned by `fun()` on each row
 #' @rdname apply_by_row
+#' @examples
+#' 
+#' ## apply_by_col() example
+#' ## Get argmax of every col
+#' apply_by_col(mat, 
+#'  function(val, row, col) if (length(val) > 0) row[which.max(val)] else 1L
+#' ) %>% unlist()
 #' @export
 apply_by_col <- function(mat, fun, ...) {
   if (storage_order(mat) != "col") {

--- a/r/R/singlecell_utils.R
+++ b/r/R/singlecell_utils.R
@@ -97,7 +97,7 @@ marker_features <- function(mat, groups, method="wilcoxon") {
 #' statistics. So when calculating `variance`, `nonzeros` and `mean` can be included with no
 #' extra calculation time, and when calculating `mean`, adding `nonzeros` will take no extra time.
 #' @examples
-#' mat.seed(12345)
+#' set.seed(12345)
 #' mat <- matrix(rpois(100, lambda = 5), nrow = 10)
 #' rownames(mat) <- paste0("gene", 1:10)
 #' colnames(mat) <- paste0("cell", 1:10) 

--- a/r/R/singlecell_utils.R
+++ b/r/R/singlecell_utils.R
@@ -35,9 +35,10 @@
 #' groups <- sample(c("A", "B", "C", "D"), ncol(mat), replace = TRUE)
 #' marker_feats <- marker_features(mat, groups)
 #' 
-#' # to see the results of one specific group vs all other groups
+#' ## to see the results of one specific group vs all other groups
 #' marker_feats %>% dplyr::filter(foreground == "A")
-#' # get only differential genes given a threshold value
+#' 
+#' ## get only differential genes given a threshold value
 #' marker_feats %>% dplyr::filter(p_val_raw < 0.05)
 #' @export
 marker_features <- function(mat, groups, method="wilcoxon") {
@@ -96,13 +97,14 @@ marker_features <- function(mat, groups, method="wilcoxon") {
 #' statistics. So when calculating `variance`, `nonzeros` and `mean` can be included with no
 #' extra calculation time, and when calculating `mean`, adding `nonzeros` will take no extra time.
 #' @examples
+#' mat.seed(12345)
 #' mat <- matrix(rpois(100, lambda = 5), nrow = 10)
 #' rownames(mat) <- paste0("gene", 1:10)
-#' colnames(mat) <- paste0("cell", 1:10)
-#' 
+#' colnames(mat) <- paste0("cell", 1:10) 
 #' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
 #' groups <- rep(c("Cluster1", "Cluster2"), each = 5)
 #' 
+#' ## When calculating only sum across two groups
 #' pseudobulk_res <- pseudobulk_matrix(
 #'   mat = mat,
 #'   cell_groups = groups,
@@ -110,13 +112,15 @@ marker_features <- function(mat, groups, method="wilcoxon") {
 #' )
 #' pseudobulk_res
 #' 
-#' # Can also request multiple summary statistics for pseudoulking
+#' ## Can also request multiple summary statistics for pseudoulking
 #' pseudobulk_res_multi <- pseudobulk_matrix(
 #'   mat = mat,
 #'   cell_groups = groups,
 #'   method = c("mean",  "variance")
 #' )
+#' 
 #' names(pseudobulk_res_multi)
+#' 
 #' pseudobulk_res_multi$mean
 #' @inheritParams marker_features
 #' @export

--- a/r/R/singlecell_utils.R
+++ b/r/R/singlecell_utils.R
@@ -30,6 +30,15 @@
 #'  - **p_val_raw**: Unadjusted p-value for differential test
 #'  - **foreground_mean**: Average value in the foreground group
 #'  - **background_mean**: Average value in the background group
+#' @examples
+#' mat <- get_demo_mat()
+#' groups <- sample(c("A", "B", "C", "D"), ncol(mat), replace = TRUE)
+#' marker_feats <- marker_features(mat, groups)
+#' 
+#' # to see the results of one specific group vs all other groups
+#' marker_feats %>% dplyr::filter(foreground == "A")
+#' # get only differential genes given a threshold value
+#' marker_feats %>% dplyr::filter(p_val_raw < 0.05)
 #' @export
 marker_features <- function(mat, groups, method="wilcoxon") {
     assert_is(mat, "IterableMatrix")
@@ -86,6 +95,29 @@ marker_features <- function(mat, groups, method="wilcoxon") {
 #' @details Some simpler stats are calculated in the process of calculating more complex
 #' statistics. So when calculating `variance`, `nonzeros` and `mean` can be included with no
 #' extra calculation time, and when calculating `mean`, adding `nonzeros` will take no extra time.
+#' @examples
+#' mat <- matrix(rpois(100, lambda = 5), nrow = 10)
+#' rownames(mat) <- paste0("gene", 1:10)
+#' colnames(mat) <- paste0("cell", 1:10)
+#' 
+#' mat <- mat %>% as("dgCMatrix") %>% as("IterableMatrix")
+#' groups <- rep(c("Cluster1", "Cluster2"), each = 5)
+#' 
+#' pseudobulk_res <- pseudobulk_matrix(
+#'   mat = mat,
+#'   cell_groups = groups,
+#'   method = "sum"
+#' )
+#' pseudobulk_res
+#' 
+#' # Can also request multiple summary statistics for pseudoulking
+#' pseudobulk_res_multi <- pseudobulk_matrix(
+#'   mat = mat,
+#'   cell_groups = groups,
+#'   method = c("mean",  "variance")
+#' )
+#' names(pseudobulk_res_multi)
+#' pseudobulk_res_multi$mean
 #' @inheritParams marker_features
 #' @export
 pseudobulk_matrix <- function(mat, cell_groups, method = "sum", threads = 0L) {

--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -181,6 +181,17 @@ setMethod("short_description", "TransformMin", function(x) {
 #' @return IterableMatrix
 #' @description **min_scalar**: Take minumum with a global constant
 #' @rdname min_elementwise
+#' @examples
+#' set.seed(12345)
+#' mat <- matrix(rpois(40, lambda = 5), nrow = 4)
+#' rownames(mat) <- paste0("gene", 1:4)
+#' 
+#' mat <- mat %>% as("dgCMatrix")
+#' mat
+#' mat <- mat %>% as("IterableMatrix")
+#' 
+#' ## min_scalar() example
+#' min_scalar(mat, 4) %>% as("dgCMatrix")
 #' @export
 min_scalar <- function(mat, val) {
   assert_is(mat, "IterableMatrix")
@@ -214,6 +225,10 @@ setMethod("short_description", "TransformMinByRow", function(x) {
 
 #' @rdname min_elementwise
 #' @description **min_by_row**: Take the minimum with a per-row constant
+#' @examples
+#' 
+#' ## min_by_row() example
+#' min_by_row(mat, 1:4) %>% as("dgCMatrix")
 #' @export
 min_by_row <- function(mat, vals) {
   if (mat@transpose) {
@@ -247,6 +262,10 @@ setMethod("short_description", "TransformMinByCol", function(x) {
 
 #' @rdname min_elementwise
 #' @description **min_by_col**: Take the minimum with a per-col constant
+#' @examples
+#' 
+#' ## min_by_col() example
+#' min_by_col(mat, 1:10) %>% as("dgCMatrix")
 #' @export
 min_by_col <- function(mat, vals) {
   if (mat@transpose) {
@@ -781,6 +800,17 @@ setMethod("+", signature(e1 = "numeric", e2 = "TransformScaleShift"), function(e
 #' @param mat Matrix-like object
 #' @param vec Numeric vector
 #' @return Matrix-like object
+#' @examples
+#' set.seed(12345)
+#' mat <- matrix(rpois(40, lambda = 5), nrow = 4)
+#' rownames(mat) <- paste0("gene", 1:4)
+#' 
+#' mat <- mat %>% as("dgCMatrix")
+#' mat
+#' mat <- mat %>% as("IterableMatrix")
+#' 
+#' ## add_rows() example
+#' add_rows(mat, 1:4) %>% as("dgCMatrix")
 #' @export
 add_rows <- function(mat, vec) {
   assert_is(mat, c("dgCMatrix", "IterableMatrix", "matrix"))
@@ -789,6 +819,10 @@ add_rows <- function(mat, vec) {
   mat + vec
 }
 #' @rdname mat_norm
+#' @examples
+#' 
+#' ## add_cols() example
+#' add_cols(mat, 1:10) %>% as("dgCMatrix")
 #' @export
 add_cols <- function(mat, vec) {
   assert_is(mat, c("dgCMatrix", "IterableMatrix", "matrix"))
@@ -797,6 +831,10 @@ add_cols <- function(mat, vec) {
   t(t(mat) + vec)
 }
 #' @rdname mat_norm
+#' @examples
+#' 
+#' ## multiply_rows() example
+#' multiply_rows(mat, 1:4) %>% as("dgCMatrix")
 #' @export
 multiply_rows <- function(mat, vec) {
   assert_is(mat, c("dgCMatrix", "IterableMatrix", "matrix"))
@@ -805,6 +843,10 @@ multiply_rows <- function(mat, vec) {
   mat * vec
 }
 #' @rdname mat_norm
+#' @examples
+#' 
+#' ## multiply_cols() example
+#' multiply_cols(mat, 1:10) %>% as("dgCMatrix")
 #' @export
 multiply_cols <- function(mat, vec) {
   assert_is(mat, c("dgCMatrix", "IterableMatrix", "matrix"))

--- a/r/man/apply_by_row.Rd
+++ b/r/man/apply_by_row.Rd
@@ -41,6 +41,37 @@ input matrix.
 If vector/matrix outputs are desired instead of lists, calling \code{unlist(x)} or \code{do.call(cbind, x)} or \code{do.call(rbind, x)}
 can convert the list output.
 }
+\examples{
+mat <- matrix(rbinom(40, 1, 0.5) * sample.int(5, 40, replace = TRUE), nrow = 4)
+rownames(mat) <- paste0("gene", 1:4)
+mat
+
+mat <- mat \%>\% as("IterableMatrix")
+
+## apply_by_row() example
+## Get mean of every row
+
+## expect an error in the case that col-major matrix is passed
+apply_by_row(mat, function(val, row, col) {sum(val) / nrow(mat)}) \%>\% 
+ unlist()
+
+## Need to transpose matrix to make sure it is in row-order
+mat_row_order <- transpose_storage_order(mat)
+
+## works as expected for row major
+apply_by_row(mat_row_order, 
+ function(val, row, col) sum(val) / ncol(mat_row_order)
+) \%>\% unlist()
+
+# Also analogous to running rowMeans()
+rowMeans(mat)
+
+## apply_by_col() example
+## Get argmax of every col
+apply_by_col(mat, 
+ function(val, row, col) if (length(val) > 0) row[which.max(val)] else 1L
+) \%>\% unlist()
+}
 \seealso{
 For an interface more similar to \code{base::apply}, see the \href{https://github.com/Yunuuuu/BPCellsArray/}{BPCellsArray}
 project. For calculating colMeans on a sparse single cell RNA matrix it is about 8x slower than \code{apply_by_col}, due to the

--- a/r/man/convert_matrix_type.Rd
+++ b/r/man/convert_matrix_type.Rd
@@ -18,3 +18,11 @@ IterableMatrix object
 \description{
 Convert the type of a matrix
 }
+\examples{
+mat <- matrix(rnorm(500), nrow = 50, ncol = 10)
+rownames(mat) <- paste0("gene", seq_len(10))
+colnames(mat) <- paste0("cell", seq_len(5))
+mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
+mat
+convert_matrix_type(mat, "float")
+}

--- a/r/man/marker_features.Rd
+++ b/r/man/marker_features.Rd
@@ -47,8 +47,9 @@ mat <- get_demo_mat()
 groups <- sample(c("A", "B", "C", "D"), ncol(mat), replace = TRUE)
 marker_feats <- marker_features(mat, groups)
 
-# to see the results of one specific group vs all other groups
+## to see the results of one specific group vs all other groups
 marker_feats \%>\% dplyr::filter(foreground == "A")
-# get only differential genes given a threshold value
+
+## get only differential genes given a threshold value
 marker_feats \%>\% dplyr::filter(p_val_raw < 0.05)
 }

--- a/r/man/marker_features.Rd
+++ b/r/man/marker_features.Rd
@@ -42,3 +42,13 @@ calculate \code{(foreground_mean - background_mean)/log(2)}. If your input
 matrix was not log-transformed, calculate \code{log2(forground_mean/background_mean)}
 }
 }
+\examples{
+mat <- get_demo_mat()
+groups <- sample(c("A", "B", "C", "D"), ncol(mat), replace = TRUE)
+marker_feats <- marker_features(mat, groups)
+
+# to see the results of one specific group vs all other groups
+marker_feats \%>\% dplyr::filter(foreground == "A")
+# get only differential genes given a threshold value
+marker_feats \%>\% dplyr::filter(p_val_raw < 0.05)
+}

--- a/r/man/mat_norm.Rd
+++ b/r/man/mat_norm.Rd
@@ -27,3 +27,24 @@ Matrix-like object
 Convenience functions for adding or multiplying
 each row / column of a matrix by a number.
 }
+\examples{
+set.seed(12345)
+mat <- matrix(rpois(40, lambda = 5), nrow = 4)
+rownames(mat) <- paste0("gene", 1:4)
+
+mat <- mat \%>\% as("dgCMatrix")
+mat
+mat <- mat \%>\% as("IterableMatrix")
+
+## add_rows() example
+add_rows(mat, 1:4) \%>\% as("dgCMatrix")
+
+## add_cols() example
+add_cols(mat, 1:10) \%>\% as("dgCMatrix")
+
+## multiply_rows() example
+multiply_rows(mat, 1:4) \%>\% as("dgCMatrix")
+
+## multiply_cols() example
+multiply_cols(mat, 1:10) \%>\% as("dgCMatrix")
+}

--- a/r/man/matrix_stats.Rd
+++ b/r/man/matrix_stats.Rd
@@ -36,3 +36,25 @@ less complex stats are calculated in the process of calculating a more complicat
 So to calculate mean and variance simultaneously, just ask for variance,
 which will compute mean and nonzero counts as a side-effect
 }
+\examples{
+mat <- matrix(rpois(100, lambda = 5), nrow = 10)
+rownames(mat) <- paste0("gene", 1:10)
+colnames(mat) <- paste0("cell", 1:10)
+mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
+
+# 1. By default, no row or column stats are calculated
+res_none <- matrix_stats(mat)
+res_none
+
+# 2. Request row variance (automatically computes mean and nonzero too)
+res_row_var <- matrix_stats(mat, row_stats = "variance")
+res_row_var
+
+# 3. Request both row variance and column variance
+res_both_var <- matrix_stats(
+  mat = mat,
+  row_stats = "variance",
+  col_stats = "mean"
+)
+res_both_var
+}

--- a/r/man/matrix_stats.Rd
+++ b/r/man/matrix_stats.Rd
@@ -42,15 +42,15 @@ rownames(mat) <- paste0("gene", 1:10)
 colnames(mat) <- paste0("cell", 1:10)
 mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
 
-# 1. By default, no row or column stats are calculated
+## By default, no row or column stats are calculated
 res_none <- matrix_stats(mat)
 res_none
 
-# 2. Request row variance (automatically computes mean and nonzero too)
+## Request row variance (automatically computes mean and nonzero too)
 res_row_var <- matrix_stats(mat, row_stats = "variance")
 res_row_var
 
-# 3. Request both row variance and column variance
+## Request both row variance and column variance
 res_both_var <- matrix_stats(
   mat = mat,
   row_stats = "variance",

--- a/r/man/min_elementwise.Rd
+++ b/r/man/min_elementwise.Rd
@@ -32,3 +32,21 @@ Take the minimum value of a matrix with a per-row, per-col, or global
 constant. This constant must be >0 to preserve sparsity of the matrix.
 This has the effect of capping the maximum value in the matrix.
 }
+\examples{
+set.seed(12345)
+mat <- matrix(rpois(40, lambda = 5), nrow = 4)
+rownames(mat) <- paste0("gene", 1:4)
+
+mat <- mat \%>\% as("dgCMatrix")
+mat
+mat <- mat \%>\% as("IterableMatrix")
+
+## min_scalar() example
+min_scalar(mat, 4) \%>\% as("dgCMatrix")
+
+## min_by_row() example
+min_by_row(mat, 1:4) \%>\% as("dgCMatrix")
+
+## min_by_col() example
+min_by_col(mat, 1:10) \%>\% as("dgCMatrix")
+}

--- a/r/man/pseudobulk_matrix.Rd
+++ b/r/man/pseudobulk_matrix.Rd
@@ -34,13 +34,14 @@ statistics. So when calculating \code{variance}, \code{nonzeros} and \code{mean}
 extra calculation time, and when calculating \code{mean}, adding \code{nonzeros} will take no extra time.
 }
 \examples{
+mat.seed(12345)
 mat <- matrix(rpois(100, lambda = 5), nrow = 10)
 rownames(mat) <- paste0("gene", 1:10)
-colnames(mat) <- paste0("cell", 1:10)
-
+colnames(mat) <- paste0("cell", 1:10) 
 mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
 groups <- rep(c("Cluster1", "Cluster2"), each = 5)
 
+## When calculating only sum across two groups
 pseudobulk_res <- pseudobulk_matrix(
   mat = mat,
   cell_groups = groups,
@@ -48,12 +49,14 @@ pseudobulk_res <- pseudobulk_matrix(
 )
 pseudobulk_res
 
-# Can also request multiple summary statistics for pseudoulking
+## Can also request multiple summary statistics for pseudoulking
 pseudobulk_res_multi <- pseudobulk_matrix(
   mat = mat,
   cell_groups = groups,
   method = c("mean",  "variance")
 )
+
 names(pseudobulk_res_multi)
+
 pseudobulk_res_multi$mean
 }

--- a/r/man/pseudobulk_matrix.Rd
+++ b/r/man/pseudobulk_matrix.Rd
@@ -4,7 +4,7 @@
 \alias{pseudobulk_matrix}
 \title{Aggregate counts matrices by cell group or feature.}
 \usage{
-pseudobulk_matrix(mat, cell_groups, method = "sum", threads = 1L)
+pseudobulk_matrix(mat, cell_groups, method = "sum", threads = 0L)
 }
 \arguments{
 \item{mat}{IterableMatrix object of dimensions features x cells}
@@ -32,4 +32,28 @@ feature.
 Some simpler stats are calculated in the process of calculating more complex
 statistics. So when calculating \code{variance}, \code{nonzeros} and \code{mean} can be included with no
 extra calculation time, and when calculating \code{mean}, adding \code{nonzeros} will take no extra time.
+}
+\examples{
+mat <- matrix(rpois(100, lambda = 5), nrow = 10)
+rownames(mat) <- paste0("gene", 1:10)
+colnames(mat) <- paste0("cell", 1:10)
+
+mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
+groups <- rep(c("Cluster1", "Cluster2"), each = 5)
+
+pseudobulk_res <- pseudobulk_matrix(
+  mat = mat,
+  cell_groups = groups,
+  method = "sum"
+)
+pseudobulk_res
+
+# Can also request multiple summary statistics for pseudoulking
+pseudobulk_res_multi <- pseudobulk_matrix(
+  mat = mat,
+  cell_groups = groups,
+  method = c("mean",  "variance")
+)
+names(pseudobulk_res_multi)
+pseudobulk_res_multi$mean
 }

--- a/r/man/pseudobulk_matrix.Rd
+++ b/r/man/pseudobulk_matrix.Rd
@@ -34,7 +34,7 @@ statistics. So when calculating \code{variance}, \code{nonzeros} and \code{mean}
 extra calculation time, and when calculating \code{mean}, adding \code{nonzeros} will take no extra time.
 }
 \examples{
-mat.seed(12345)
+set.seed(12345)
 mat <- matrix(rpois(100, lambda = 5), nrow = 10)
 rownames(mat) <- paste0("gene", 1:10)
 colnames(mat) <- paste0("cell", 1:10) 

--- a/r/man/svds.Rd
+++ b/r/man/svds.Rd
@@ -69,6 +69,19 @@ the column norm of \eqn{A - 1c'}{A - 1 * c'}.
 Default is \code{FALSE}. Ignored in BPCells}
 }
 }
+\examples{
+mat <- matrix(rnorm(500), nrow = 50, ncol = 10)
+rownames(mat) <- paste0("gene", seq_len(50))
+colnames(mat) <- paste0("cell", seq_len(10))
+mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
+svd_res <- svds(mat, k = 5)
+names(svd_res)
+svd_res$d
+dim(svd_res$u)
+dim(svd_res$v)
+# Can also pass in values directly into RSpectra::svds
+svd_res <- svds(mat, k = 5, opts=c(maxitr = 500))
+}
 \references{
 Qiu Y, Mei J (2022). \emph{RSpectra: Solvers for Large-Scale Eigenvalue and SVD Problems}. R package version 0.16-1, \url{https://CRAN.R-project.org/package=RSpectra}.
 }

--- a/r/man/svds.Rd
+++ b/r/man/svds.Rd
@@ -74,10 +74,15 @@ mat <- matrix(rnorm(500), nrow = 50, ncol = 10)
 rownames(mat) <- paste0("gene", seq_len(50))
 colnames(mat) <- paste0("cell", seq_len(10))
 mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
+
 svd_res <- svds(mat, k = 5)
+
 names(svd_res)
+
 svd_res$d
+
 dim(svd_res$u)
+
 dim(svd_res$v)
 # Can also pass in values directly into RSpectra::svds
 svd_res <- svds(mat, k = 5, opts=c(maxitr = 500))

--- a/r/man/transpose_storage_order.Rd
+++ b/r/man/transpose_storage_order.Rd
@@ -43,9 +43,11 @@ rownames(mat) <- paste0("gene", seq_len(10))
 colnames(mat) <- paste0("cell", seq_len(5))
 mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
 mat
-# A regular transpose operation switches a user's rows and cols 
+
+## A regular transpose operation switches a user's rows and cols 
 t(mat)
-# Running `transpose_storage_order()` instead changes whether the storage is in row-major or col-major,
-# but does not switch the rows and cols
+
+## Running `transpose_storage_order()` instead changes whether the storage is in row-major or col-major,
+## but does not switch the rows and cols
 transpose_storage_order(mat)
 }

--- a/r/man/transpose_storage_order.Rd
+++ b/r/man/transpose_storage_order.Rd
@@ -37,3 +37,15 @@ and sort_bytes (1GiB) parameters allow ~85GB of data to be sorted with two
 passes through the data, and ~7.3TB of data to be sorted in three passes
 through the data.
 }
+\examples{
+mat <- matrix(rnorm(50), nrow = 10, ncol = 5)
+rownames(mat) <- paste0("gene", seq_len(10))
+colnames(mat) <- paste0("cell", seq_len(5))
+mat <- mat \%>\% as("dgCMatrix") \%>\% as("IterableMatrix")
+mat
+# A regular transpose operation switches a user's rows and cols 
+t(mat)
+# Running `transpose_storage_order()` instead changes whether the storage is in row-major or col-major,
+# but does not switch the rows and cols
+transpose_storage_order(mat)
+}


### PR DESCRIPTION
Created examples for many functions in the `Matrix operations` tab in the reference. 
The ones that were left out were:

- `sctransform_pearson()`: I'm aware of how to use the function given your docs tests and some of the issues, but I don't think I completely get the intuition of how to show the best way to utilize it without Seurat.  I think you are in a better position to write an example for this.
- `regress_out()`: Similar reasoning to above
- All of the `IterableMatrix` methods functions:  I think these should be a separate PR

Styling wise, I tried to utilize smaller matrices when they made sense as to not take up too much compute. However, I did use `get_demo_mat()` in `marker_features()` as I felt it illustrated the functionality a little bit better.  I tried to seperate examples for examples sitting within the same `.Rd`, using some line sep and a line indicating the function being showcased.  

Nothing too fancy in terms of parameterization usage.  I think this should be the way to go until we have at least a single example for every function for CRAN.  Then we can flesh out where we deem needed