### PR TITLE
[r] add examples for fragment io operations

### DIFF
--- a/r/R/fragments.R
+++ b/r/R/fragments.R
@@ -159,6 +159,31 @@ setMethod("short_description", "FragmentsTsv", function(x) {
 #'     insertion at the end coordinate rather than the base before the end coordinate. This is the
 #'     10x default, though it's not quite standard for the bed file format.
 #' @return 10x fragments file object
+#' @examples
+#' ## Download example fragments from pbmc 500 dataset and save in temp directory
+#' data_dir <- file.path(tempdir(), "frags_10x")
+#' dir.create(data_dir, recursive = TRUE, showWarnings = FALSE)
+#' url_base <- "https://cf.10xgenomics.com/samples/cell-atac/2.0.0/atac_pbmc_500_nextgem/"
+#' frags_file <- "atac_pbmc_500_nextgem_fragments.tsv.gz"
+#' atac_raw_url <- paste0(url_base, frags_file)
+#' if (!file.exists(file.path(data_dir, frags_file))) {
+#'  download.file(atac_raw_url, file.path(data_dir, frags_file), mode="wb")
+#' }
+#' 
+#' #######################################################################
+#' ## open_fragments_10x() example
+#' frags <- open_fragments_10x(
+#'  file.path(data_dir, frags_file)
+#' )
+#' ## A Fragments object imported from 10x will not have cell/chromosome 
+#' ## information directly known unless written as a BPCells fragment object
+#' frags
+#' 
+#' frags %>% write_fragments_dir(
+#'  file.path(data_dir, "demo_frags_from_h5"), 
+#'  overwrite = TRUE
+#' )
+#' #######################################################################
 #' @export
 open_fragments_10x <- function(path, comment = "#", end_inclusive = TRUE) {
   assert_is_file(path, extension = c(".tsv", ".tsv.gz"))
@@ -180,6 +205,15 @@ open_fragments_10x <- function(path, comment = "#", end_inclusive = TRUE) {
 #' @details **write_fragments_10x**
 #'
 #' Fragments will be written to disk immediately, then returned in a readable object.
+#' @examples
+#' #######################################################################
+#' ## write_fragments_10x() example
+#' frags <- write_fragments_10x(
+#'  frags,
+#'  file.path(data_dir, paste0("new_", frags_file))
+#' )
+#' frags
+#' #######################################################################
 #' @export
 write_fragments_10x <- function(fragments, path, end_inclusive = TRUE, append_5th_column = FALSE) {
   assert_is_file(path, must_exist = FALSE, extension = c(".tsv", ".tsv.gz"))
@@ -291,6 +325,19 @@ setMethod("short_description", "PackedMemFragments", function(x) {
 #' @param compress Whether or not to compress the data. With compression, storage size is
 #' be about half the size of a gzip-compressed 10x fragments file.
 #' @rdname fragment_io
+#' @examples
+#' ## Create temporary directory to keep demo fragments
+#' data_dir <- file.path(tempdir(), "frags")
+#' dir.create(data_dir, recursive = TRUE, showWarnings = FALSE)
+#' ## Get demo frags loaded from disk
+#' frags <- get_demo_frags()
+#' frags
+#' 
+#' #######################################################################
+#' ## write_fragments_memory() example
+#' frags_memory <- write_fragments_memory(frags)
+#' frags_memory
+#' #######################################################################
 #' @export
 write_fragments_memory <- function(fragments, compress = TRUE) {
   assert_is(fragments, "IterableFragments")
@@ -347,6 +394,16 @@ setMethod("short_description", "FragmentsDir", function(x) {
 #'   pass a temp path as a string to customize the temp dir location.
 #' @return Fragment object
 #' @rdname fragment_io
+#' @examples
+#' #######################################################################
+#' ## write_fragments_dir() example
+#' frags <- write_fragments_dir(
+#'  frags_memory, 
+#'  file.path(data_dir, "demo_frags"),
+#'  overwrite = TRUE
+#' )
+#' frags
+#' #######################################################################
 #' @export
 write_fragments_dir <- function(fragments, dir, compress = TRUE, buffer_size = 1024L, overwrite = FALSE) {
   assert_is(fragments, "IterableFragments")
@@ -383,6 +440,12 @@ write_fragments_dir <- function(fragments, dir, compress = TRUE, buffer_size = 1
 }
 
 #' @rdname fragment_io
+#' @examples
+#' #######################################################################
+#' ## open_fragments_dir() example
+#' frags <- open_fragments_dir(file.path(data_dir, "demo_frags"))
+#' frags
+#' #######################################################################
 #' @export
 open_fragments_dir <- function(dir, buffer_size = 1024L) {
   assert_is_file(dir)
@@ -438,6 +501,16 @@ setMethod("short_description", "FragmentsHDF5", function(x) {
 #' @param gzip_level Gzip compression level. Default is 0 (no compression). This is recommended when both compression and
 #'     compatibility with outside programs is required. Otherwise, using compress=TRUE is recommended
 #'     as it is >10x faster with often similar compression levels. 
+#' @examples
+#' #######################################################################
+#' ## write_fragments_hdf5() example
+#' frags_hdf5 <- write_fragments_hdf5(
+#'  frags, 
+#'  file.path(data_dir, "demo_frags.h5"),
+#'  overwrite = TRUE
+#' )
+#' frags_hdf5
+#' #######################################################################
 #' @export
 write_fragments_hdf5 <- function(
     fragments, 
@@ -494,6 +567,12 @@ write_fragments_hdf5 <- function(
 }
 
 #' @rdname fragment_io
+#' @examples
+#' #######################################################################
+#' ## open_fragments_hdf5() example
+#' frags_hdf5 <- open_fragments_hdf5(file.path(data_dir, "demo_frags.h5"))
+#' frags_hdf5
+#' #######################################################################
 #' @export
 open_fragments_hdf5 <- function(path, group = "fragments", buffer_size = 16384L) {
   assert_is_file(path)
@@ -532,6 +611,40 @@ open_fragments_hdf5 <- function(path, group = "fragments", buffer_size = 16384L)
 #'    for GRanges and false for other formats
 #'    (see this [archived UCSC blogpost](https://web.archive.org/web/20210920203703/http://genome.ucsc.edu/blog/the-ucsc-genome-browser-coordinate-counting-systems/))
 #' @return **convert_to_fragments()**: IterableFragments object
+#' @examples
+#' frags_table <- tibble::tibble(
+#'   chr = paste0("chr", 1:10),
+#'   start = 0,
+#'   end = 5,
+#'   cell_id = "cell1"
+#' )
+#' frags_table
+#' 
+#' frags_granges <- GenomicRanges::makeGRangesFromDataFrame(
+#'  frags_table, keep.extra.columns = TRUE
+#' )
+#' frags_granges
+#' 
+#' #######################################################################
+#' ## convert_to_fragments() example
+#' frags <- convert_to_fragments(frags_granges)
+#' frags
+#' #######################################################################
+#' #######################################################################
+#' ## as(x, "IterableFragments") example
+#' frags <- as(frags_table, "IterableFragments")
+#' frags
+#' #######################################################################
+#' #######################################################################
+#' ## as(bpcells_fragments, "data.frame") example
+#' frags_table <- as(frags, "data.frame")
+#' frags_table
+#' #######################################################################
+#' ## as(bpcells_fragments, "GRanges") example
+#' frags_granges <- as(frags, "GRanges")
+#' frags_granges
+#' #######################################################################
+#' 
 #' @rdname fragment_R_conversion
 #' @export
 convert_to_fragments <- function(x, zero_based_coords = !is(x, "GRanges")) {

--- a/r/man/fragment_R_conversion.Rd
+++ b/r/man/fragment_R_conversion.Rd
@@ -35,3 +35,38 @@ The main conversion method is R's builtin \code{as()} function, though the
 GRanges, BPCells assumes a 0-based, end-exclusive coordinate system. (See
 \link{genomic-ranges-like} reference for details)
 }
+\examples{
+frags_table <- tibble::tibble(
+  chr = paste0("chr", 1:10),
+  start = 0,
+  end = 5,
+  cell_id = "cell1"
+)
+frags_table
+
+frags_granges <- GenomicRanges::makeGRangesFromDataFrame(
+ frags_table, keep.extra.columns = TRUE
+)
+frags_granges
+
+#######################################################################
+## convert_to_fragments() example
+frags <- convert_to_fragments(frags_granges)
+frags
+#######################################################################
+#######################################################################
+## as(x, "IterableFragments") example
+frags <- as(frags_table, "IterableFragments")
+frags
+#######################################################################
+#######################################################################
+## as(bpcells_fragments, "data.frame") example
+frags_table <- as(frags, "data.frame")
+frags_table
+#######################################################################
+## as(bpcells_fragments, "GRanges") example
+frags_granges <- as(frags, "GRanges")
+frags_granges
+#######################################################################
+
+}

--- a/r/man/fragment_io.Rd
+++ b/r/man/fragment_io.Rd
@@ -74,3 +74,45 @@ allows saving within existing hdf5 files to group data together, and the in
 memory format provides the fastest performance in the event memory usage is
 unimportant.
 }
+\examples{
+## Create temporary directory to keep demo fragments
+data_dir <- file.path(tempdir(), "frags")
+dir.create(data_dir, recursive = TRUE, showWarnings = FALSE)
+## Get demo frags loaded from disk
+frags <- get_demo_frags()
+frags
+
+#######################################################################
+## write_fragments_memory() example
+frags_memory <- write_fragments_memory(frags)
+frags_memory
+#######################################################################
+#######################################################################
+## write_fragments_dir() example
+frags <- write_fragments_dir(
+ frags_memory, 
+ file.path(data_dir, "demo_frags"),
+ overwrite = TRUE
+)
+frags
+#######################################################################
+#######################################################################
+## open_fragments_dir() example
+frags <- open_fragments_dir(file.path(data_dir, "demo_frags"))
+frags
+#######################################################################
+#######################################################################
+## write_fragments_hdf5() example
+frags_hdf5 <- write_fragments_hdf5(
+ frags, 
+ file.path(data_dir, "demo_frags.h5"),
+ overwrite = TRUE
+)
+frags_hdf5
+#######################################################################
+#######################################################################
+## open_fragments_hdf5() example
+frags_hdf5 <- open_fragments_hdf5(file.path(data_dir, "demo_frags.h5"))
+frags_hdf5
+#######################################################################
+}

--- a/r/man/open_fragments_10x.Rd
+++ b/r/man/open_fragments_10x.Rd
@@ -46,3 +46,37 @@ No disk operations will take place until the fragments are used in a function
 
 Fragments will be written to disk immediately, then returned in a readable object.
 }
+\examples{
+## Download example fragments from pbmc 500 dataset and save in temp directory
+data_dir <- file.path(tempdir(), "frags_10x")
+dir.create(data_dir, recursive = TRUE, showWarnings = FALSE)
+url_base <- "https://cf.10xgenomics.com/samples/cell-atac/2.0.0/atac_pbmc_500_nextgem/"
+frags_file <- "atac_pbmc_500_nextgem_fragments.tsv.gz"
+atac_raw_url <- paste0(url_base, frags_file)
+if (!file.exists(file.path(data_dir, frags_file))) {
+ download.file(atac_raw_url, file.path(data_dir, frags_file), mode="wb")
+}
+
+#######################################################################
+## open_fragments_10x() example
+frags <- open_fragments_10x(
+ file.path(data_dir, frags_file)
+)
+## A Fragments object imported from 10x will not have cell/chromosome 
+## information directly known unless written as a BPCells fragment object
+frags
+
+frags \%>\% write_fragments_dir(
+ file.path(data_dir, "demo_frags_from_h5"), 
+ overwrite = TRUE
+)
+#######################################################################
+#######################################################################
+## write_fragments_10x() example
+frags <- write_fragments_10x(
+ frags,
+ file.path(data_dir, paste0("new_", frags_file))
+)
+frags
+#######################################################################
+}


### PR DESCRIPTION
Pretty self explanatory, with the design choice logic from https://github.com/bnprks/BPCells/pull/207. I did add some horizontal breaks as discussed from our chat, for multiple functions in the same Rd. This should help with readability going forward.

I chose to use a 500 cell dataset instead for opening frags, in consideration of download size and space.  I was thinking about doing a QC step so we could write faster, but I feel it doesn't make sense to throw the intermediate filtering in the function examples