### PR TITLE
[r][cpp] Force pow to use strictly positive exponent

### DIFF
--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -144,7 +144,7 @@ setMethod("short_description", "TransformPow", function(x) {
   )
 })
 
-#' @describeIn IterableMatrix-methods Calculate x^y (elementwise)
+#' @describeIn IterableMatrix-methods Calculate x^y (elementwise; y > 0)
 setMethod("^", signature(e1 = "IterableMatrix", e2 = "numeric"), function(e1, e2) {
   assert_len(e2, 1)
   assert_true(e2 > 0)

--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -147,7 +147,7 @@ setMethod("short_description", "TransformPow", function(x) {
 #' @describeIn IterableMatrix-methods Calculate x^y (elementwise)
 setMethod("^", signature(e1 = "IterableMatrix", e2 = "numeric"), function(e1, e2) {
   assert_len(e2, 1)
-  assert_true(e2 != 0)
+  assert_true(e2 > 0)
   if (e2 == 2) {
     wrapMatrix("TransformSquare", convert_matrix_type(e1, "double"))
   } else {

--- a/r/man/IterableMatrix-methods.Rd
+++ b/r/man/IterableMatrix-methods.Rd
@@ -234,7 +234,7 @@ Generic methods and built-in functions for IterableMatrix objects
 
 \item \code{expm1_slow()}: Calculate exp(x) - 1 (non-SIMD version)
 
-\item \code{e1^e2}: Calculate x^y (elementwise)
+\item \code{e1^e2}: Calculate x^y (elementwise; y > 0)
 
 \item \code{e1 < e2}: Binarize matrix according to numeric < matrix comparison
 

--- a/r/src/bpcells-cpp/matrixTransforms/Pow.cpp
+++ b/r/src/bpcells-cpp/matrixTransforms/Pow.cpp
@@ -12,6 +12,12 @@
 
 namespace BPCells {
 
+Pow::Pow(std::unique_ptr<MatrixLoader<double>> &&loader, TransformFit fit) : MatrixTransform::MatrixTransform(std::move(loader), fit) {
+    if (fit.global_params.size() != 1 || fit.global_params(0) <= 0) {
+        throw std::runtime_error("C++ error constructing Pow: exponent <= 0");
+    }
+}
+
 bool Pow::load() {
     if (!loader->load()) return false;
 

--- a/r/src/bpcells-cpp/matrixTransforms/Pow.h
+++ b/r/src/bpcells-cpp/matrixTransforms/Pow.h
@@ -14,7 +14,7 @@ namespace BPCells {
 
 class Pow : public MatrixTransform {
   public:
-    using MatrixTransform::MatrixTransform;
+    Pow(std::unique_ptr<MatrixLoader<double>> &&loader, TransformFit fit);
 
     bool load() override;
 };

--- a/r/tests/testthat/test-matrix_transforms.R
+++ b/r/tests/testthat/test-matrix_transforms.R
@@ -118,6 +118,7 @@ test_that("pow works", {
 
     expect_equal(m^2, m2^2 %>% as("dgCMatrix"))
     expect_equal(m^3, m2^3 %>% as("dgCMatrix"))
+    expect_error(m2^-2)
 })
 
 test_that("binarize works", {


### PR DESCRIPTION
I realized that we shouldn't support negative exponents for powers, since that would mess up all the zero values in the matrix. Just updated a few bounds checks to make that happen