### PR TITLE
[r] fix nesting bug in `range_distance_to_nearest()`

### DIFF
--- a/r/R/geneScores.R
+++ b/r/R/geneScores.R
@@ -46,7 +46,7 @@ range_distance_to_nearest <- function(ranges, addArchRBug = FALSE, zero_based_co
       ) %>%
       dplyr::pull(from) %>%
       unique()
-    ranges <- ranges[-overlaps, ]
+    if (length(overlaps) != 0) ranges <- ranges[-overlaps, ]
   }
 
   dists <- ranges %>%

--- a/r/tests/testthat/test-atac_utils.R
+++ b/r/tests/testthat/test-atac_utils.R
@@ -27,6 +27,31 @@ test_that("range_overlaps works", {
   expect_identical(range_overlaps(a, b), expected)
 })
 
+test_that("range_distance_to_nearest works", {
+  frags <- tibble::tibble(
+    chr = "chr1",
+    start = seq(10, 410, 100),
+    end = start + 50,
+    strand = "+"
+  )
+  res <- tibble::tibble(
+    upstream = c(Inf, rep(51, 4)),
+    downstream = c(rep(51, 4), Inf)
+  )
+  expect_identical(
+    range_distance_to_nearest(frags),
+    res
+  )
+  frags_with_nested <- frags %>% 
+    tibble::add_row(chr = "chr1", start = 11, end = 20, strand = "+")
+  res_with_nested <- res %>%
+    tibble::add_row(upstream = 0, downstream = 0)
+  expect_identical(
+    range_distance_to_nearest(frags_with_nested),
+    res_with_nested
+  )
+})
+
 test_that("tile_ranges works", {
   frags <- convert_to_fragments(tibble::tibble(
     chr = paste0("chr", 1:10),


### PR DESCRIPTION
Within the codeblock conditioned on param `AddArchRBug`, all ranges are deemed as overlaps when no ranges are actually present.  This results in all `upstream` and `downstream` values being set to 0.  
The bug occurs because `overlaps` becomes set to `integer(0)`.  When running `range[-overlaps,]`, the intended effect would be to remove 0 rows, rather than removing all rows.
I fixed this just by doing a length condition check after calculating `overlaps`.  Also added a small test for this function, for range with and without nesting.