### PR TITLE
[r] Fix check to enable GRanges conversion 

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -16,6 +16,7 @@
 - Fix `gene_score_archr()` when `chromosome_sizes` argument is not sorted. (Thanks to @Baboon61 for reporting issue #188)
 - Fix matrix transpose error when BPCells is loaded via `devtools::load_all()` and `BiocGenerics` has been imported previously. (pull request #191)
 - Fix error when using a single group in `write_insertion_bedgraph()` (pull request #214)
+- Fix GRanges conversion functions sometimes not being defined if BPCells is built as a binary package prior to GenomicRanges being installed. (pull request #231; thanks to @mfansler for reporting issue #229)
 
 # BPCells 0.3.0 (12/21/2024)
 

--- a/r/R/fragments.R
+++ b/r/R/fragments.R
@@ -562,32 +562,34 @@ convert_to_fragments <- function(x, zero_based_coords = !is(x, "GRanges")) {
 
 
 # Define converters with GRanges if we have the GenomicRanges package available
-if (requireNamespace("GenomicRanges", quietly = TRUE)) {
-  setAs("IterableFragments", "GRanges", function(from) {
-    if (is(from, "UnpackedMemFragments")) {
-      frags <- from
-    } else {
-      frags <- write_fragments_memory(from, compress = FALSE)
-    }
-    # Get the differences between adjacent elements on the chr_ptr list
-    # to calculate how many values are in each chromosome
-    chr_counts <- frags@chr_ptr[c(FALSE, TRUE)] - frags@chr_ptr[c(TRUE, FALSE)]
-    # order by where this chromosome range starts
-    chr_order <- order(frags@chr_ptr[c(TRUE, FALSE)])
+rlang::on_load({
+  if (requireNamespace("GenomicRanges", quietly = TRUE)) {
+    setAs("IterableFragments", "GRanges", function(from) {
+      if (is(from, "UnpackedMemFragments")) {
+        frags <- from
+      } else {
+        frags <- write_fragments_memory(from, compress = FALSE)
+      }
+      # Get the differences between adjacent elements on the chr_ptr list
+      # to calculate how many values are in each chromosome
+      chr_counts <- frags@chr_ptr[c(FALSE, TRUE)] - frags@chr_ptr[c(TRUE, FALSE)]
+      # order by where this chromosome range starts
+      chr_order <- order(frags@chr_ptr[c(TRUE, FALSE)])
 
-    GenomicRanges::GRanges(
-      seqnames = S4Vectors::Rle(values = factor(chrNames(frags)[chr_order], chrNames(frags)), lengths = chr_counts[chr_order]),
-      ranges = IRanges::IRanges(
-        start = frags@start + 1,
-        end = frags@end
-      ),
-      cell_id = factor(frags@cell_names[frags@cell + 1], frags@cell_names)
-    )
-  })
-  setAs("GRanges", "IterableFragments", function(from) {
-    convert_to_fragments(from)
-  })
-}
+      GenomicRanges::GRanges(
+        seqnames = S4Vectors::Rle(values = factor(chrNames(frags)[chr_order], chrNames(frags)), lengths = chr_counts[chr_order]),
+        ranges = IRanges::IRanges(
+          start = frags@start + 1,
+          end = frags@end
+        ),
+        cell_id = factor(frags@cell_names[frags@cell + 1], frags@cell_names)
+      )
+    })
+    setAs("GRanges", "IterableFragments", function(from) {
+      convert_to_fragments(from)
+    })
+  }
+})
 
 setAs("IterableFragments", "data.frame", function(from) {
   if (is(from, "UnpackedMemFragments")) {


### PR DESCRIPTION
This should fix #229, which is likely caused by a combination of specific installation procedures and the BPCells R package getting built before the GenomicRanges package is installed.

For what it's worth, I don't reproduce issue #229 on a fresh `renv` environment when running `renv::install("bnprks/BPCells/r@v0.3.0")`, followed later by `renv::install("bioc::GenomicRanges")`.

Since we want these conversion functions to work regardless of how/when BPCells was installed, wrapping this in an `rlang::on_load()` call makes it a load-time rather than an install-time check.