### PR TITLE
[cpp] add fix for `write_matrix_hdf5()` when overwriting nonexistent file

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -16,6 +16,7 @@
 - Fix `gene_score_archr()` when `chromosome_sizes` argument is not sorted. (Thanks to @Baboon61 for reporting issue #188)
 - Fix matrix transpose error when BPCells is loaded via `devtools::load_all()` and `BiocGenerics` has been imported previously. (pull request #191)
 - Fix error when using a single group in `write_insertion_bedgraph()` (pull request #214)
+- Fix error in `write_matrix_hdf5()` when overwriting to a `.h5` file that does not exist. (pull request #234)
 
 # BPCells 0.3.0 (12/21/2024)
 

--- a/r/src/matrix_io.cpp
+++ b/r/src/matrix_io.cpp
@@ -991,6 +991,10 @@ read_hdf5_string_cpp(std::string path, std::string group, uint32_t buffer_size) 
 
 // [[Rcpp::export]]
 bool hdf5_group_exists_cpp(std::string path, std::string group) {
+    // Only check for group if the path itself exists
+    if (!std::filesystem::exists(path)) {
+        return false;
+    }
     H5ReaderBuilder rb(path, "/", 1);
     return rb.getGroup().exist(group);
 }

--- a/r/tests/testthat/test-matrix_io.R
+++ b/r/tests/testthat/test-matrix_io.R
@@ -550,6 +550,14 @@ test_that("H5 overwrite works", {
     open_matrix_hdf5(file.path(dir, "overwrite.h5"), "mat") %>%
       as("dgCMatrix")
   )
+  # Should work even when the overwritten h5 doesn't exist
+  expect_identical(
+    as(m2, "dgCMatrix"),
+    m2 %>% 
+      as("IterableMatrix") %>%
+      write_matrix_hdf5(file.path(dir, "overwrite_new.h5"), "mat", overwrite = TRUE) %>%
+      as("dgCMatrix")
+  )
   # It should be okay even if we overwrite the same source we're loading from
   expect_identical(
     as(m2, "dgCMatrix")[c(1,3),],
@@ -558,6 +566,8 @@ test_that("H5 overwrite works", {
       write_matrix_hdf5(file.path(dir, "overwrite.h5"), "mat", overwrite=TRUE) %>%
       as("dgCMatrix")
   )
+
+  
 })
 
 test_that("Dir overwrite works", {


### PR DESCRIPTION
Fixes #211

Pretty self explanatory.  Added a conditional to `hdf5_group_exists_cpp` to ensure we're not checking for a group in a file that doesn't exist. 