### PR TITLE
[r][cpp] Add missing user interrupt checks

### DIFF
--- a/r/src/fragment_io.cpp
+++ b/r/src/fragment_io.cpp
@@ -299,7 +299,9 @@ bool fragments_identical_cpp(SEXP fragments1, SEXP fragments2) {
             Rcerr << "Different chromosome ID loaded" << std::endl;
             return false;
         }
+        uint32_t count = 0;
         while (true) {
+            if (count++ % (1 << 14) == 0) Rcpp::checkUserInterrupt();
             bool res1 = i1.nextFrag();
             bool res2 = i2.nextFrag();
             if (res1 != res2) {

--- a/r/src/fragment_utils.cpp
+++ b/r/src/fragment_utils.cpp
@@ -30,13 +30,6 @@
 
 #include "bpcells-cpp/matrixIterators/PeakMatrix.h"
 #include "bpcells-cpp/matrixIterators/TileMatrix.h"
-// #include "matrixIterators/PeakMatrix2.h"
-// #include "matrixIterators/PeakMatrix3.h"
-// #include "matrixIterators/PeakMatrix4.h"
-// #include "matrixIterators/PeakMatrix5.h"
-// #include "matrixIterators/PeakMatrix6.h"
-// #include "matrixIterators/TileMatrix.h"
-// #include "matrixIterators/TileMatrix2.h"
 
 using namespace Rcpp;
 using namespace BPCells;
@@ -51,6 +44,7 @@ NumericVector scan_fragments_cpp(SEXP fragments) {
 
     while (iter.nextChr()) {
         while (iter.nextFrag()) {
+            if (len % (1 << 14) == 0) Rcpp::checkUserInterrupt();
             len++;
             start_sum += iter.start();
             end_sum += iter.end();
@@ -219,8 +213,10 @@ std::vector<int> fragment_lengths_cpp(SEXP fragments) {
 
     std::vector<int> lengths(0);
 
+    uint32_t count = 0;
     while (iter.nextChr()) {
         while (iter.nextFrag()) {
+            if (count++ % (1 << 14) == 0) Rcpp::checkUserInterrupt();
             uint32_t width = iter.end() - iter.start();
             if (width >= lengths.size()) lengths.resize(width + 1);
             lengths[width] += 1;


### PR DESCRIPTION
I noticed that rowMaxs and colMaxs didn't check for users pressing ctrl-C when I was working on a recent PR, so I did a sweep of all the `*.cpp` files in the `src` dir to make sure everything quits promptly when ctrl-C is pressed.

My rule of thumb for check frequency is that every column is fine for a matrix since there are 1000s of columns usually, but for fragments it's necessary to check within each chromosome since a single chromosome might be too long to wait through.