### PR TITLE
Use `int32_t` and `int64_t` for 10x H5 writing function

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -10,7 +10,8 @@
 - Fixed memory errors when running `writeInsertionBed()` and `writeInsertionBedGraph()` (pull request #{118, 134})
 - Export `merge_peaks_iterative()`, which helps create non-overlapping peak sets.  (pull request #216)
 - Add support for `uint16_t` when reading in anndata matrices using `open_matrix_anndata_hdf5()`. (pull request #248)
-
+- Switch `write_matrix_10x_hdf5()` to use signed rather than unsigned integers for `indices`, `indptr`, and `shape` to improve
+  compatibility with 10x-produced files. (Thanks to @ycli1995 for pull request #256)
 
 ## Bug-fixes
 - Fix error message printing when MACS crashes during `call_peaks_macs()` (pull request #175)

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -473,6 +473,10 @@ hdf5_group_objnames_cpp <- function(path, group) {
     .Call(`_BPCells_hdf5_group_objnames_cpp`, path, group)
 }
 
+hdf5_storage_type_cpp <- function(path, group) {
+    .Call(`_BPCells_hdf5_storage_type_cpp`, path, group)
+}
+
 import_matrix_market_cpp <- function(mtx_path, row_names, col_names, outdir, tmpdir, load_bytes, sort_buffer_bytes, row_major) {
     invisible(.Call(`_BPCells_import_matrix_market_cpp`, mtx_path, row_names, col_names, outdir, tmpdir, load_bytes, sort_buffer_bytes, row_major))
 }

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -1631,6 +1631,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// hdf5_storage_type_cpp
+std::string hdf5_storage_type_cpp(std::string path, std::string group);
+RcppExport SEXP _BPCells_hdf5_storage_type_cpp(SEXP pathSEXP, SEXP groupSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type group(groupSEXP);
+    rcpp_result_gen = Rcpp::wrap(hdf5_storage_type_cpp(path, group));
+    return rcpp_result_gen;
+END_RCPP
+}
 // import_matrix_market_cpp
 void import_matrix_market_cpp(std::string mtx_path, std::vector<std::string> row_names, std::vector<std::string> col_names, std::string outdir, std::string tmpdir, uint64_t load_bytes, uint64_t sort_buffer_bytes, bool row_major);
 RcppExport SEXP _BPCells_import_matrix_market_cpp(SEXP mtx_pathSEXP, SEXP row_namesSEXP, SEXP col_namesSEXP, SEXP outdirSEXP, SEXP tmpdirSEXP, SEXP load_bytesSEXP, SEXP sort_buffer_bytesSEXP, SEXP row_majorSEXP) {
@@ -2670,6 +2682,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_BPCells_read_hdf5_string_cpp", (DL_FUNC) &_BPCells_read_hdf5_string_cpp, 3},
     {"_BPCells_hdf5_group_exists_cpp", (DL_FUNC) &_BPCells_hdf5_group_exists_cpp, 2},
     {"_BPCells_hdf5_group_objnames_cpp", (DL_FUNC) &_BPCells_hdf5_group_objnames_cpp, 2},
+    {"_BPCells_hdf5_storage_type_cpp", (DL_FUNC) &_BPCells_hdf5_storage_type_cpp, 2},
     {"_BPCells_import_matrix_market_cpp", (DL_FUNC) &_BPCells_import_matrix_market_cpp, 8},
     {"_BPCells_iterate_matrix_log1p_cpp", (DL_FUNC) &_BPCells_iterate_matrix_log1p_cpp, 1},
     {"_BPCells_iterate_matrix_log1psimd_cpp", (DL_FUNC) &_BPCells_iterate_matrix_log1psimd_cpp, 1},

--- a/r/src/bpcells-cpp/matrixIterators/ImportMatrix10xHDF5.cpp
+++ b/r/src/bpcells-cpp/matrixIterators/ImportMatrix10xHDF5.cpp
@@ -100,10 +100,10 @@ StoredMatrixWriter<T> create10xFeatureMatrix(
     wb.createStringWriter("features/_all_tag_keys")->write(VecStringReader(tag_keys));
 
     return StoredMatrixWriter(
-        wb.create<int64_t>("indices").convert<uint32_t>(),
+        wb.create<int32_t>("indices").convert<uint32_t>(),
         wb.create<T>("data"),
         wb.create<int64_t>("indptr").convert<uint64_t>(),
-        wb.create<int64_t>("shape").convert<uint32_t>(),
+        wb.create<int32_t>("shape").convert<uint32_t>(),
         std::make_unique<NullStringWriter>(),
         std::make_unique<NullStringWriter>(),
         std::make_unique<NullStringWriter>()

--- a/r/src/bpcells-cpp/matrixIterators/ImportMatrix10xHDF5.cpp
+++ b/r/src/bpcells-cpp/matrixIterators/ImportMatrix10xHDF5.cpp
@@ -100,10 +100,10 @@ StoredMatrixWriter<T> create10xFeatureMatrix(
     wb.createStringWriter("features/_all_tag_keys")->write(VecStringReader(tag_keys));
 
     return StoredMatrixWriter(
-        wb.createULongWriter("indices").convert<uint32_t>(),
+        wb.create<int64_t>("indices").convert<uint32_t>(),
         wb.create<T>("data"),
-        wb.createULongWriter("indptr"),
-        wb.createUIntWriter("shape"),
+        wb.create<int64_t>("indptr").convert<uint64_t>(),
+        wb.create<int64_t>("shape").convert<uint32_t>(),
         std::make_unique<NullStringWriter>(),
         std::make_unique<NullStringWriter>(),
         std::make_unique<NullStringWriter>()

--- a/r/src/bpcells-cpp/matrixIterators/ImportMatrix10xHDF5.cpp
+++ b/r/src/bpcells-cpp/matrixIterators/ImportMatrix10xHDF5.cpp
@@ -100,7 +100,7 @@ StoredMatrixWriter<T> create10xFeatureMatrix(
     wb.createStringWriter("features/_all_tag_keys")->write(VecStringReader(tag_keys));
 
     return StoredMatrixWriter(
-        wb.create<int32_t>("indices").convert<uint32_t>(),
+        wb.create<int64_t>("indices").convert<uint32_t>(),
         wb.create<T>("data"),
         wb.create<int64_t>("indptr").convert<uint64_t>(),
         wb.create<int32_t>("shape").convert<uint32_t>(),

--- a/r/src/matrix_io.cpp
+++ b/r/src/matrix_io.cpp
@@ -1005,6 +1005,21 @@ std::vector<std::string> hdf5_group_objnames_cpp(std::string path, std::string g
     return rb.getGroup().listObjectNames();
 }
 
+// [[Rcpp::export]]
+std::string hdf5_storage_type_cpp(std::string path, std::string group) {
+    HighFive::SilenceHDF5 s;
+    H5ReaderBuilder rb(path, "/", 1);
+    HighFive::DataType type = rb.getGroup().getDataSet(group).getDataType();
+    if (type == HighFive::AtomicType<int32_t>()) return "int32_t";
+    else if (type == HighFive::AtomicType<int64_t>()) return "int64_t";
+    else if (type == HighFive::AtomicType<uint32_t>()) return "uint32_t";
+    else if (type == HighFive::AtomicType<uint64_t>()) return "uint64_t";
+    else if (type == HighFive::AtomicType<float>()) return "float";
+    else if (type == HighFive::AtomicType<double>()) return "double";
+    throw std::runtime_error("hdf5_group_type_cpp: Unrecongnized group type: " + type.string());
+    return type.string();
+}
+
 // MTX format
 
 // [[Rcpp::export]]

--- a/r/tests/testthat/test-matrix_io.R
+++ b/r/tests/testthat/test-matrix_io.R
@@ -38,6 +38,18 @@ test_that("Write 10x matrix to HDF5", {
   }
 })
 
+test_that("Write 10x matrix uses correct HDF5 data types", {
+  dir <- withr::local_tempdir()
+  mat_path <- file.path(dir, "10x.h5")
+  m <- generate_sparse_matrix(10, 9, fraction_nonzero=0.2) %>%
+    as("IterableMatrix") %>%
+    convert_matrix_type("uint32_t")
+  write_matrix_10x_hdf5(m, mat_path)
+  expect_identical(hdf5_storage_type_cpp(mat_path, "matrix/indices"), "int64_t")
+  expect_identical(hdf5_storage_type_cpp(mat_path, "matrix/indptr"), "int64_t")
+  expect_identical(hdf5_storage_type_cpp(mat_path, "matrix/shape"), "int32_t")
+})
+
 test_that("Memory Matrix round-trips", {
   dir <- withr::local_tempdir()
   args <- list(


### PR DESCRIPTION
Hi, @bnprks 
When I tried to use `BPCells::write_matrix_10x_hdf5` in `loupeR` from https://github.com/10XGenomics/loupeR , the program `louper.exe create --input=<h5file> --output=<cloupe file>` raised an error:
```
indices: cannot convert dataset to int64
```
When I change the original `uint32/64_t` to `int32/64_t` in "indices" and "indptr", the error is fixed. Maybe it would be better if the HDF5 files written by `BPCells` use data types more consistent with 10x's expected formats, to improve compatibility with downstream tools.
