### PR TITLE
[cpp] Remove unsafe address vector address refs

### DIFF
--- a/r/src/bpcells-cpp/fragmentIterators/RegionSelect.cpp
+++ b/r/src/bpcells-cpp/fragmentIterators/RegionSelect.cpp
@@ -106,9 +106,9 @@ bool RegionSelect::load() {
             // Check if we've gotten to a region beyond the current chromosome
             if (r.chr != current_chr_id) {
                 if (invert_selection) {
-                    std::memmove(&cell[loaded], &cell[i], sizeof(uint32_t) * (capacity - i));
-                    std::memmove(&end[loaded], &end[i], sizeof(uint32_t) * (capacity - i));
-                    std::memmove(&start[loaded], &start[i], sizeof(uint32_t) * (capacity - i));
+                    std::memmove(cell + loaded, cell + i, sizeof(uint32_t) * (capacity - i));
+                    std::memmove(end + loaded, end + i, sizeof(uint32_t) * (capacity - i));
+                    std::memmove(start + loaded, start + i, sizeof(uint32_t) * (capacity - i));
                     loaded += capacity - i;
                     return true;
                 } else {
@@ -130,9 +130,9 @@ bool RegionSelect::load() {
             // 2. Binary search for frag.start >= region.end to find all the remaining overlaps
             auto easy_overlaps = std::lower_bound(&start[i], &start[capacity], r.end) - &start[i];
             if (!invert_selection) {
-                std::memmove(&cell[loaded], &cell[i], sizeof(uint32_t) * easy_overlaps);
-                std::memmove(&end[loaded], &end[i], sizeof(uint32_t) * easy_overlaps);
-                std::memmove(&start[loaded], &start[i], sizeof(uint32_t) * easy_overlaps);
+                std::memmove(cell + loaded, cell + i, sizeof(uint32_t) * easy_overlaps);
+                std::memmove(end + loaded, end + i, sizeof(uint32_t) * easy_overlaps);
+                std::memmove(start + loaded, start + i, sizeof(uint32_t) * easy_overlaps);
                 loaded += easy_overlaps;
             }
             i += easy_overlaps;

--- a/r/src/bpcells-cpp/fragmentIterators/StoredFragments.cpp
+++ b/r/src/bpcells-cpp/fragmentIterators/StoredFragments.cpp
@@ -46,7 +46,7 @@ void StoredFragmentsBase::readEndMaxBuf(uint64_t start_idx, uint64_t end_idx) {
         end_max.ensureCapacity(1);
         uint64_t load_amount = std::min(end_max.capacity(), (uint64_t) end_max_buf.size() - i);
 
-        std::memmove(&end_max_buf[i], end_max.data(), load_amount * sizeof(uint32_t));
+        std::memmove(end_max_buf.data() + i, end_max.data(), load_amount * sizeof(uint32_t));
         i += load_amount;
         if (i >= end_max_buf.size()) break;
         end_max.advance(load_amount);

--- a/r/src/bpcells-cpp/fragmentUtils/InsertionIterator.h
+++ b/r/src/bpcells-cpp/fragmentUtils/InsertionIterator.h
@@ -69,8 +69,8 @@ class InsertionIterator {
         }
 
         // Copy data to remove our used insertions the start of end_data
-        std::memmove(&end_data[0], &end_data[end_idx], sizeof(uint32_t) * leftover_size);
-        std::memmove(&end_cell[0], &end_cell[end_idx], sizeof(uint32_t) * leftover_size);
+        std::memmove(end_data.data(), end_data.data() + end_idx, sizeof(uint32_t) * leftover_size);
+        std::memmove(end_cell.data(), end_cell.data() + end_idx, sizeof(uint32_t) * leftover_size);
 
         // Reset our vectors
         end_idx = 0;


### PR DESCRIPTION
Running on my Arch Linux machine, I get crashes in the test suite caused by taking &vec[0] of an empty vector in InsertionIterator.h. No data would be read/written in the empty case, but to avoid these crashes I switched to using
pointer arithmetic here and in any similar calls to `std::memmove` in the rest of the codebase.