### PR TITLE
[cpp] add version detection for highway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ rsync.sh
 src/Makevars
 tools/h5write
 tools/cxx17_filesystem
+r/tools/hwy-test.cpp
 tools/*.exe
 vignettes/*.html
 vignettes/pbmc-3k-data
@@ -29,7 +30,7 @@ cpp-tests
 venv
 wheelhouse
 
-# A few convenience igores for my development cruft
+# A few convenience ignores for my development cruft
 failing_test.R
 mytest*.R
 .clang-format

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,6 +24,7 @@
 - Fix error in `write_matrix_hdf5()` when overwriting to a `.h5` file that does not exist. (pull request #234)
 - Fix `configure` script to use a pre-installed `libhwy` if available during installation time. (Thanks to @mfansler for submitting PR #228)
 - Fix line-ending issue that caused windows-created matrices to not be readable on other platforms. (pull request #257; thanks to @pavsol for reporting issue #253)
+- Fix compilation when there exists a system-installed `libhwy` that is too old. (pull request #288, thanks to @GerardoZA for reporting issue #285)
 
 # BPCells 0.3.0 (12/21/2024)
 

--- a/r/configure
+++ b/r/configure
@@ -154,7 +154,7 @@ fi
 ############################
 # Build Highway SIMD library
 ############################
-printf "\nTesting availability of highway SIMD library\n"
+printf "\nTesting availability of highway SIMD library...\n"
 HWY_OK=""
 # Minimum required version (may override via env var HWY_MIN_VERSION=X.Y.Z)
 HWY_MIN_VERSION=${HWY_MIN_VERSION:-1.0.5}

--- a/r/configure
+++ b/r/configure
@@ -187,19 +187,17 @@ else
         HWY_LIBS=""
     fi
     # Only attempt second compile if pkg-config succeeded
-    if [ -n "$HWY_LIBS" ]; then
-        if $CXX tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > /dev/null 2> "$HWY_COMPILE_LOG"; then
-            HWY_VERSION_OUTPUT=$(tools/hwy-test)
-            printf "$HWY_VERSION_OUTPUT"
-            HWY_OK="yes"
-        elif grep -q "Highway too old" "$HWY_COMPILE_LOG"; then
+    if [ -n "$HWY_LIBS" ] && $CXX tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > /dev/null 2> "$HWY_COMPILE_LOG"; then
+        HWY_VERSION_OUTPUT=$(tools/hwy-test)
+        printf "$HWY_VERSION_OUTPUT"
+        HWY_OK="yes"
+    elif grep -q "Highway too old" "$HWY_COMPILE_LOG"; then
             printf "\nHighway is installed but too old: %s\n" "$(sed -n 's/.*#pragma message: //p' "$HWY_COMPILE_LOG")"
-        else
+    else
             printf "Highway not found or unusable\n"
-        fi
     fi
 fi
-rm -f tools/hwy-test "$HWY_COMPILE_LOG"
+rm -f tools/hwy-test "$HWY_COMPILE_LOG" tools/hwy-test.cpp
 
 if [ -z $HWY_OK ]; then
     if [ ! -f tools/highway/lib/libhwy.a ]; then

--- a/r/configure
+++ b/r/configure
@@ -154,11 +154,53 @@ fi
 ############################
 # Build Highway SIMD library
 ############################
-printf "\nTesting availability of highway SIMD library..."
+printf "\nTesting availability of highway SIMD library\n"
 HWY_OK=""
+# Minimum required version (may override via env var HWY_MIN_VERSION=X.Y.Z)
+HWY_MIN_VERSION=${HWY_MIN_VERSION:-1.0.5}
+IFS=. read -r HWY_MIN_MAJOR HWY_MIN_MINOR HWY_MIN_PATCH <<< "$HWY_MIN_VERSION"
+sed \
+  -e "s/@HWY_MIN_MAJOR@/$HWY_MIN_MAJOR/g" \
+  -e "s/@HWY_MIN_MINOR@/$HWY_MIN_MINOR/g" \
+  -e "s/@HWY_MIN_PATCH@/$HWY_MIN_PATCH/g" \
+  -e "s/@HWY_MIN_VERSION@/$HWY_MIN_VERSION/g" \
+  tools/hwy-test.cpp.in > tools/hwy-test.cpp
+
 HWY_CFLAGS="-Ibpcells-cpp"
 HWY_LIBS="-lhwy"
-$CXX tools/hwy-test.cpp $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS 2>&3 && HWY_OK="yes";
+# Use a compile log to keep error/pragma messages
+HWY_COMPILE_LOG=$(mktemp)
+# Try to compile with hardcoded flags first
+if $CXX tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > /dev/null 2> "$HWY_COMPILE_LOG"; then
+    HWY_VERSION_OUTPUT=$(tools/hwy-test)
+    printf "$HWY_VERSION_OUTPUT"
+    HWY_OK="yes"
+else
+    # Fallback to pkg-config if available
+    if pkg-config --exists libhwy 2>/dev/null; then
+        HWY_CFLAGS="$(pkg-config --cflags libhwy 2>&3) $HWY_CFLAGS"
+        HWY_LIBS="$(pkg-config --libs libhwy 2>&3)"
+    elif pkg-config --exists hwy 2>/dev/null; then
+        HWY_CFLAGS="$(pkg-config --cflags hwy 2>&3) $HWY_CFLAGS"
+        HWY_LIBS="$(pkg-config --libs hwy 2>&3)"
+    else
+        HWY_LIBS=""
+    fi
+    # Only attempt second compile if pkg-config succeeded
+    if [ -n "$HWY_LIBS" ]; then
+        if $CXX tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > /dev/null 2> "$HWY_COMPILE_LOG"; then
+            HWY_VERSION_OUTPUT=$(tools/hwy-test)
+            printf "$HWY_VERSION_OUTPUT"
+            HWY_OK="yes"
+        elif grep -q "Highway too old" "$HWY_COMPILE_LOG"; then
+            printf "\nHighway is installed but too old: %s\n" "$(sed -n 's/.*#pragma message: //p' "$HWY_COMPILE_LOG")"
+        else
+            printf "Highway not found or unusable\n"
+        fi
+    fi
+fi
+rm -f tools/hwy-test "$HWY_COMPILE_LOG"
+
 if [ -z $HWY_OK ]; then
     if [ ! -f tools/highway/lib/libhwy.a ]; then
         printf "\nBuilding highway SIMD library from source\n"

--- a/r/configure.win
+++ b/r/configure.win
@@ -137,7 +137,7 @@ else
         HWY_LIBS=""
     fi
     # Only attempt second compile if pkg-config succeeded
-    if [ -n "$HWY_LIBS" ] && if "$CXX" tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > NUL 2> "$HWY_COMPILE_LOG"; then
+    if [ -n "$HWY_LIBS" ] && $CXX tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > NUL 2> "$HWY_COMPILE_LOG"; then
         HWY_VERSION_OUTPUT=$(tools/hwy-test.exe)
         echo "$HWY_VERSION_OUTPUT"
         HWY_OK="yes"

--- a/r/configure.win
+++ b/r/configure.win
@@ -99,7 +99,7 @@ fi
 ############################
 # Build Highway SIMD library
 ############################
-printf "\nTesting availability of highway SIMD library..."
+printf "\nTesting availability of highway SIMD library...\n"
 HWY_OK=""
 HWY_MIN_VERSION=${HWY_MIN_VERSION:-1.0.5}
 

--- a/r/configure.win
+++ b/r/configure.win
@@ -137,16 +137,14 @@ else
         HWY_LIBS=""
     fi
     # Only attempt second compile if pkg-config succeeded
-    if [ -n "$HWY_LIBS" ]; then
-        if "$CXX" tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > NUL 2> "$HWY_COMPILE_LOG"; then
-            HWY_VERSION_OUTPUT=$(tools/hwy-test.exe)
-            echo "$HWY_VERSION_OUTPUT"
-            HWY_OK="yes"
-        elif grep -q "Highway too old" "$HWY_COMPILE_LOG"; then
-            echo "Highway is installed but too old: $(sed -n 's/.*#pragma message: //p' "$HWY_COMPILE_LOG")"
-        else
-            echo "Highway not found or unusable"
-        fi
+    if [ -n "$HWY_LIBS" ] && if "$CXX" tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > NUL 2> "$HWY_COMPILE_LOG"; then
+        HWY_VERSION_OUTPUT=$(tools/hwy-test.exe)
+        echo "$HWY_VERSION_OUTPUT"
+        HWY_OK="yes"
+    elif grep -q "Highway too old" "$HWY_COMPILE_LOG"; then
+        echo "Highway is installed but too old: $(sed -n 's/.*#pragma message: //p' "$HWY_COMPILE_LOG")"
+    else
+        echo "Highway not found or unusable"
     fi
 fi
 rm -f tools/hwy-test.exe tools/hwy-test.cpp "$HWY_COMPILE_LOG"

--- a/r/configure.win
+++ b/r/configure.win
@@ -101,8 +101,56 @@ fi
 ############################
 printf "\nTesting availability of highway SIMD library..."
 HWY_OK=""
+HWY_MIN_VERSION=${HWY_MIN_VERSION:-1.0.5}
+
+# Use sed to split version
+HWY_MIN_MAJOR=$(echo "$HWY_MIN_VERSION" | sed 's/\..*//')
+HWY_MIN_MINOR=$(echo "$HWY_MIN_VERSION" | sed 's/^[^.]*\.//;s/\..*//')
+HWY_MIN_PATCH=$(echo "$HWY_MIN_VERSION" | sed 's/^.*\..*\.//')
+
+# Generate test TU
+sed \
+  -e "s/@HWY_MIN_MAJOR@/$HWY_MIN_MAJOR/g" \
+  -e "s/@HWY_MIN_MINOR@/$HWY_MIN_MINOR/g" \
+  -e "s/@HWY_MIN_PATCH@/$HWY_MIN_PATCH/g" \
+  -e "s/@HWY_MIN_VERSION@/$HWY_MIN_VERSION/g" \
+  tools/hwy-test.cpp.in > tools/hwy-test.cpp
+
 HWY_CFLAGS="-Ibpcells-cpp"
 HWY_LIBS="-lhwy"
+# Use a compile log to keep error/pragma messages
+HWY_COMPILE_LOG=tools/hwy-test-log.txt
+# Try hardcoded flags
+if $CXX tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > NUL 2> "$HWY_COMPILE_LOG"; then
+    HWY_VERSION_OUTPUT=$(tools/hwy-test.exe)
+    echo "$HWY_VERSION_OUTPUT"
+    HWY_OK="yes"
+else
+    # Fallback to pkg-config
+    if pkg-config --exists libhwy 2> NUL; then
+        HWY_CFLAGS="$(pkg-config --cflags libhwy 2>&1) $HWY_CFLAGS"
+        HWY_LIBS="$(pkg-config --libs libhwy 2>&1)"
+    elif pkg-config --exists hwy 2> NUL; then
+        HWY_CFLAGS="$(pkg-config --cflags hwy 2>&1) $HWY_CFLAGS"
+        HWY_LIBS="$(pkg-config --libs hwy 2>&1)"
+    else
+        HWY_LIBS=""
+    fi
+    # Only attempt second compile if pkg-config succeeded
+    if [ -n "$HWY_LIBS" ]; then
+        if "$CXX" tools/hwy-test.cpp -o tools/hwy-test $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS > NUL 2> "$HWY_COMPILE_LOG"; then
+            HWY_VERSION_OUTPUT=$(tools/hwy-test.exe)
+            echo "$HWY_VERSION_OUTPUT"
+            HWY_OK="yes"
+        elif grep -q "Highway too old" "$HWY_COMPILE_LOG"; then
+            echo "Highway is installed but too old: $(sed -n 's/.*#pragma message: //p' "$HWY_COMPILE_LOG")"
+        else
+            echo "Highway not found or unusable"
+        fi
+    fi
+fi
+rm -f tools/hwy-test.exe tools/hwy-test.cpp "$HWY_COMPILE_LOG"
+
 $CXX tools/hwy-test.cpp $CXXFLAGS $LDFLAGS $HWY_CFLAGS $HWY_LIBS 2>&3 && HWY_OK="yes";
 if [ -z $HWY_OK ]; then
     if [ ! -f tools/highway/lib/libhwy.a ]; then

--- a/r/tools/hwy-test.cpp.in
+++ b/r/tools/hwy-test.cpp.in
@@ -1,0 +1,31 @@
+#include <hwy/highway.h>
+#include <hwy/aligned_allocator.h>
+#include <iostream>
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#ifndef HWY_MAJOR
+#error "Missing HWY_MAJOR"
+#endif
+#ifndef HWY_MINOR
+#error "Missing HWY_MINOR"
+#endif
+#ifndef HWY_PATCH
+#error "Missing HWY_PATCH"
+#endif
+
+#if (HWY_MAJOR < @HWY_MIN_MAJOR@) || \
+    (HWY_MAJOR == @HWY_MIN_MAJOR@ && HWY_MINOR < @HWY_MIN_MINOR@) || \
+    (HWY_MAJOR == @HWY_MIN_MAJOR@ && HWY_MINOR == @HWY_MIN_MINOR@ && HWY_PATCH < @HWY_MIN_PATCH@)
+#pragma message("Highway too old: need >=@HWY_MIN_VERSION@ for BPCells (found " STR(HWY_MAJOR) "." STR(HWY_MINOR) "." STR(HWY_PATCH) ")")
+#error "Highway too old"
+#endif
+
+int main() {
+    auto ptr = hwy::AllocateAligned<float>(1024);
+    ptr[0] = 1.0f;
+    std::cout << "Highway version: "
+              << HWY_MAJOR << "." << HWY_MINOR << "." << HWY_PATCH << std::endl;
+    return 0;
+}


### PR DESCRIPTION
# Background
We use a package named highway, which helps with added efficiency in automatically choosing the best CPU intrinsics for vectorization based on your architecture.

Previously, there was a previous bug during compilation, which did not allow BPCells to utilize Highway if it was already installed. This was fixed. However, I suspect that if you have an older version of highway, installation would fail, and would not fall back to our packaged version of highway.  We can see this in #285, where `BroadcastLane`, which is part of highway is not being detected.

# Fix
I made some general improvements to `configure` for highway,  in both the logging and the detection.
I added some version detection within `hwy-test.cpp`, which is version templated through `hwy-test.cpp.in`.  I also added a fallback to using `pkg-config` found libraries, if the first compilation try fails.  There is also some additional clarity on whether the compilation fails because of versioning, or from failing to compile for a different reason.

Fixes #285