### PR TITLE
[r] Fix `knn_hnsw()` input query rowname bug

### DIFF
--- a/r/R/clustering.R
+++ b/r/R/clustering.R
@@ -387,8 +387,8 @@ knn_hnsw <- function(data, query = NULL, k = 10, metric = c("euclidean", "cosine
     }
   }
 
-  rownames(res$idx) <- rownames(data)
-  rownames(res$dist) <- rownames(data)
+  rownames(res$idx) <- rownames(query)
+  rownames(res$dist) <- rownames(query)
   return(res)
 }
 

--- a/r/tests/testthat/test-clustering.R
+++ b/r/tests/testthat/test-clustering.R
@@ -74,6 +74,15 @@ test_that("igraph clustering doesn't crash", {
     expect_no_condition(cluster_graph_louvain(graph))
 })
 
+test_that("knn_hnsw rownames come from query", {
+    skip_if_not_installed("RcppHNSW")
+    data <- matrix(rnorm(200), nrow=20, dimnames=list(paste0("data_", 1:20)))
+    query <- matrix(rnorm(50), nrow=5, dimnames=list(paste0("query_", 1:5)))
+    res <- knn_hnsw(data, query=query, k=3, verbose=FALSE)
+    expect_equal(rownames(res$idx), rownames(query))
+    expect_equal(rownames(res$dist), rownames(query))
+})
+
 test_that("cluster_cells_graph works", {
     skip_if_not_installed("RcppAnnoy")
     skip_if_not_installed("RcppHNSW")


### PR DESCRIPTION
This pull request fixes a bug in `knn_hnsw()` where the rownames of the result matrices were incorrectly taken from `data` instead of `query` when a separate query matrix was provided. This caused the output to have wrong rownames (from the reference data) rather than the rownames corresponding to the actual query points. When no query is given, `query` is already set to `data`, so behavior is unchanged in that case. (`r/R/clustering.R`)