### PR TITLE
[r][cpp] add element-wise matrix addition

### DIFF
--- a/cpp/tests/test-matrixMath.cpp
+++ b/cpp/tests/test-matrixMath.cpp
@@ -18,6 +18,7 @@
 #include <matrixIterators/MatrixIndexSelect.h>
 #include <matrixIterators/MatrixIterator.h>
 #include <matrixIterators/StoredMatrix.h>
+#include <matrixIterators/MatrixAddition.h>
 
 #include <matrixTransforms/Log1p.h>
 #include <matrixTransforms/Pow.h>
@@ -411,4 +412,22 @@ TEST(MatrixMath, Shift) {
     r2.write(*mat);
 
     EXPECT_TRUE(MatrixXd(r2.getMat()).isApprox(ans2));
+}
+
+TEST(MatrixMath, Add) {
+    SparseMatrix<double> m1 = generate_mat(100, 50, 125123);
+    SparseMatrix<double> m2 = generate_mat(100, 50, 999777);
+    MatrixXd ans = MatrixXd(m1) + MatrixXd(m2);
+
+    MatrixAddition<double> add(
+        std::make_unique<CSparseMatrix<double>>(get_map(m1)),
+        std::make_unique<CSparseMatrix<double>>(get_map(m2))
+    );
+
+    checkMultiplyOps(add, ans);
+
+    CSparseMatrixWriter<double> res;
+    add.restart();
+    res.write(add);
+    EXPECT_TRUE(MatrixXd(res.getMat()).isApprox(ans));
 }

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -661,6 +661,18 @@ iterate_matrix_multiply_double_cpp <- function(left, right) {
     .Call(`_BPCells_iterate_matrix_multiply_double_cpp`, left, right)
 }
 
+iterate_matrix_add_uint32_t_cpp <- function(left, right) {
+    .Call(`_BPCells_iterate_matrix_add_uint32_t_cpp`, left, right)
+}
+
+iterate_matrix_add_float_cpp <- function(left, right) {
+    .Call(`_BPCells_iterate_matrix_add_float_cpp`, left, right)
+}
+
+iterate_matrix_add_double_cpp <- function(left, right) {
+    .Call(`_BPCells_iterate_matrix_add_double_cpp`, left, right)
+}
+
 iterate_matrix_mask_uint32_t_cpp <- function(mat, mask, invert) {
     .Call(`_BPCells_iterate_matrix_mask_uint32_t_cpp`, mat, mask, invert)
 }

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -478,6 +478,28 @@ setMethod("short_description", "MatrixAddition", function(x) {
   )
 })
 
+setMethod("+", signature(e1 = "IterableMatrix", e2 = "IterableMatrix"), function(e1, e2) {
+  if (e1@transpose != e2@transpose) stop("Cannot add matrices with different internal transpose states.\nPlease use transpose_storage_order().")
+  if (e1@transpose) {
+    return(t(t(e1) + t(e2)))
+  }
+
+  assert_true(nrow(e1) == nrow(e2) && ncol(e1) == ncol(e2))
+
+  # If types are mismatched, default to double precision for both
+  type_e1 <- matrix_type(e1)
+  type_e2 <- matrix_type(e2)
+  if (type_e1 != type_e2 && type_e1 != "double") e1 <- convert_matrix_type(e1, "double")
+  if (type_e1 != type_e2 && type_e2 != "double") e2 <- convert_matrix_type(e2, "double")
+
+  dim <- c(nrow(e1), ncol(e1))
+  dimnames <- list(
+    merge_dimnames(rownames(e1), rownames(e2), "+", "row"),
+    merge_dimnames(colnames(e1), colnames(e2), "+", "column")
+  )
+  new("MatrixAddition", left = e1, right = e2, transpose = FALSE, dim = dim, dimnames = dimnames)
+})
+
 # Subsetting on MatrixAddition
 setMethod("[", "MatrixAddition", function(x, i, j, ...) {
   if (missing(x)) stop("x is missing in matrix selection")

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -442,6 +442,65 @@ setMethod("%*%", signature(x = "dgCMatrix", y = "IterableMatrix"), function(x, y
 })
 
 
+# Element-wise matrix addition
+setClass("MatrixAddition",
+  contains = "IterableMatrix",
+  slots = c(
+    left = "IterableMatrix",
+    right = "IterableMatrix"
+  ),
+  prototype = list(
+    left = NULL,
+    right = NULL
+  )
+)
+setMethod("matrix_type", signature(x = "MatrixAddition"), function(x) matrix_type(x@left))
+setMethod("matrix_inputs", "MatrixAddition", function(x) list(x@left, x@right))
+setMethod("matrix_inputs<-", "MatrixAddition", function(x, ..., value) {
+  assert_is(value, "list")
+  assert_len(value, 2)
+  for (v in value) assert_is(v, "IterableMatrix")
+  x@left <- value[[1]]
+  x@right <- value[[2]]
+  x
+})
+
+setMethod("iterate_matrix", "MatrixAddition", function(x) {
+  iter_function <- get(sprintf("iterate_matrix_add_%s_cpp", matrix_type(x)))
+  iter_function(iterate_matrix(x@left), iterate_matrix(x@right))
+})
+
+setMethod("short_description", "MatrixAddition", function(x) {
+  sprintf(
+    "Add sparse matrices: %s (%dx%d) + %s (%dx%d)",
+    class(x@left), nrow(x@left), ncol(x@left),
+    class(x@right), nrow(x@right), ncol(x@right)
+  )
+})
+
+# Subsetting on MatrixAddition
+setMethod("[", "MatrixAddition", function(x, i, j, ...) {
+  if (missing(x)) stop("x is missing in matrix selection")
+  # Handle transpose via recursive call
+  if (x@transpose) {
+    return(t(t(x)[rlang::maybe_missing(j), rlang::maybe_missing(i)]))
+  }
+
+  i <- split_selection_index(i, nrow(x), rownames(x))
+  j <- split_selection_index(j, ncol(x), colnames(x))
+  # If we're just reordering rows/cols, do a standard matrix selection
+  if (rlang::is_missing(i$subset) && rlang::is_missing(j$subset)) {
+    return(callNextMethod(x, unsplit_selection(i), unsplit_selection(j)))
+  }
+  x <- selection_fix_dims(x, rlang::maybe_missing(i$subset), rlang::maybe_missing(j$subset))
+
+  # Selection will be a no-op if i or j is missing
+  x@left <- x@left[rlang::maybe_missing(i$subset), rlang::maybe_missing(j$subset)]
+  x@right <- x@right[rlang::maybe_missing(i$subset), rlang::maybe_missing(j$subset)]
+
+  x[rlang::maybe_missing(i$reorder), rlang::maybe_missing(j$reorder)]
+})
+
 # Subsetting on MatrixMultiply
 setMethod("[", "MatrixMultiply", function(x, i, j, ...) {
   if (missing(x)) stop("x is missing in matrix selection")

--- a/r/R/matrix.R
+++ b/r/R/matrix.R
@@ -500,6 +500,11 @@ setMethod("+", signature(e1 = "IterableMatrix", e2 = "IterableMatrix"), function
   new("MatrixAddition", left = e1, right = e2, transpose = FALSE, dim = dim, dimnames = dimnames)
 })
 
+# Element-wise matrix subtraction via MatrixAddition
+setMethod("-", signature(e1 = "IterableMatrix", e2 = "IterableMatrix"), function(e1, e2) {
+  e1 + (-1 * e2)
+})
+
 # Subsetting on MatrixAddition
 setMethod("[", "MatrixAddition", function(x, i, j, ...) {
   if (missing(x)) stop("x is missing in matrix selection")

--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -752,27 +752,6 @@ setMethod("+", signature(e1 = "numeric", e2 = "IterableMatrix"), function(e1, e2
   e2 <- wrapMatrix("TransformScaleShift", convert_matrix_type(e2, "double"))
   e2 + e1
 })
-setMethod("+", signature(e1 = "IterableMatrix", e2 = "IterableMatrix"), function(e1, e2) {
-  if (e1@transpose != e2@transpose) stop("Cannot add matrices with different internal transpose states.\nPlease use transpose_storage_order().")
-  if (e1@transpose) {
-    return(t(t(e1) + t(e2)))
-  }
-
-  assert_true(nrow(e1) == nrow(e2) && ncol(e1) == ncol(e2))
-
-  # If types are mismatched, default to double precision for both
-  type_e1 <- matrix_type(e1)
-  type_e2 <- matrix_type(e2)
-  if (type_e1 != type_e2 && type_e1 != "double") e1 <- convert_matrix_type(e1, "double")
-  if (type_e1 != type_e2 && type_e2 != "double") e2 <- convert_matrix_type(e2, "double")
-
-  dim <- c(nrow(e1), ncol(e1))
-  dimnames <- list(
-    merge_dimnames(rownames(e1), rownames(e2), "+", "row"),
-    merge_dimnames(colnames(e1), colnames(e2), "+", "column")
-  )
-  new("MatrixAddition", left = e1, right = e2, transpose = FALSE, dim = dim, dimnames = dimnames)
-})
 # Note: we skip numeric / IterableMatrix as it would result in a lot of infinities for dividing by 0.
 #' @describeIn IterableMatrix-methods Divide by a constant, or divide rows by a vector length nrow(mat)
 #' @examples

--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -752,6 +752,7 @@ setMethod("+", signature(e1 = "numeric", e2 = "IterableMatrix"), function(e1, e2
   e2 <- wrapMatrix("TransformScaleShift", convert_matrix_type(e2, "double"))
   e2 + e1
 })
+# Note: setMethod("+", IterableMatrix, IterableMatrix) lives in matrix.R, alongside the MatrixAddition class definition.
 # Note: we skip numeric / IterableMatrix as it would result in a lot of infinities for dividing by 0.
 #' @describeIn IterableMatrix-methods Divide by a constant, or divide rows by a vector length nrow(mat)
 #' @examples

--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -740,7 +740,7 @@ setMethod("*", signature(e1 = "numeric", e2 = "IterableMatrix"), function(e1, e2
 #' mat + 1:nrow(mat)
 #' 
 #' ## Element-wise addition of two IterableMatrix objects
-#' mat1 + mat2
+#' mat + (mat * 2)
 #'
 setMethod("+", signature(e1 = "IterableMatrix", e2 = "numeric"), function(e1, e2) {
   if (all(e2 == 0)) return(e1)
@@ -761,10 +761,10 @@ setMethod("+", signature(e1 = "IterableMatrix", e2 = "IterableMatrix"), function
   assert_true(nrow(e1) == nrow(e2) && ncol(e1) == ncol(e2))
 
   # If types are mismatched, default to double precision for both
-  type_x <- matrix_type(e1)
-  type_y <- matrix_type(e2)
-  if (type_x != type_y && type_x != "double") e1 <- convert_matrix_type(e1, "double")
-  if (type_x != type_y && type_y != "double") e2 <- convert_matrix_type(e2, "double")
+  type_e1 <- matrix_type(e1)
+  type_e2 <- matrix_type(e2)
+  if (type_e1 != type_e2 && type_e1 != "double") e1 <- convert_matrix_type(e1, "double")
+  if (type_e1 != type_e2 && type_e2 != "double") e2 <- convert_matrix_type(e2, "double")
 
   dim <- c(nrow(e1), ncol(e1))
   dimnames <- list(

--- a/r/R/transforms.R
+++ b/r/R/transforms.R
@@ -727,7 +727,8 @@ setMethod("*", signature(e1 = "numeric", e2 = "IterableMatrix"), function(e1, e2
   e2 <- wrapMatrix("TransformScaleShift", convert_matrix_type(e2, "double"))
   e2 * e1
 })
-#' @describeIn IterableMatrix-methods Add a constant, or row-wise addition with a vector length nrow(mat)
+#' @describeIn IterableMatrix-methods Add a constant, row-wise addition with a vector length nrow(mat),
+#'   or element-wise addition of two IterableMatrix objects
 #' @examples
 #' #######################################################################
 #' ## `e1 + e2` example
@@ -738,7 +739,9 @@ setMethod("*", signature(e1 = "numeric", e2 = "IterableMatrix"), function(e1, e2
 #' ## Adding row-wise by a vector of length `nrow(mat)`
 #' mat + 1:nrow(mat)
 #' 
-#' 
+#' ## Element-wise addition of two IterableMatrix objects
+#' mat1 + mat2
+#'
 setMethod("+", signature(e1 = "IterableMatrix", e2 = "numeric"), function(e1, e2) {
   if (all(e2 == 0)) return(e1)
   e1 <- wrapMatrix("TransformScaleShift", convert_matrix_type(e1, "double"))
@@ -748,6 +751,27 @@ setMethod("+", signature(e1 = "numeric", e2 = "IterableMatrix"), function(e1, e2
   if (all(e1 == 0)) return(e2)
   e2 <- wrapMatrix("TransformScaleShift", convert_matrix_type(e2, "double"))
   e2 + e1
+})
+setMethod("+", signature(e1 = "IterableMatrix", e2 = "IterableMatrix"), function(e1, e2) {
+  if (e1@transpose != e2@transpose) stop("Cannot add matrices with different internal transpose states.\nPlease use transpose_storage_order().")
+  if (e1@transpose) {
+    return(t(t(e1) + t(e2)))
+  }
+
+  assert_true(nrow(e1) == nrow(e2) && ncol(e1) == ncol(e2))
+
+  # If types are mismatched, default to double precision for both
+  type_x <- matrix_type(e1)
+  type_y <- matrix_type(e2)
+  if (type_x != type_y && type_x != "double") e1 <- convert_matrix_type(e1, "double")
+  if (type_x != type_y && type_y != "double") e2 <- convert_matrix_type(e2, "double")
+
+  dim <- c(nrow(e1), ncol(e1))
+  dimnames <- list(
+    merge_dimnames(rownames(e1), rownames(e2), "+", "row"),
+    merge_dimnames(colnames(e1), colnames(e2), "+", "column")
+  )
+  new("MatrixAddition", left = e1, right = e2, transpose = FALSE, dim = dim, dimnames = dimnames)
 })
 # Note: we skip numeric / IterableMatrix as it would result in a lot of infinities for dividing by 0.
 #' @describeIn IterableMatrix-methods Divide by a constant, or divide rows by a vector length nrow(mat)

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -2212,6 +2212,42 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// iterate_matrix_add_uint32_t_cpp
+SEXP iterate_matrix_add_uint32_t_cpp(SEXP left, SEXP right);
+RcppExport SEXP _BPCells_iterate_matrix_add_uint32_t_cpp(SEXP leftSEXP, SEXP rightSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type right(rightSEXP);
+    rcpp_result_gen = Rcpp::wrap(iterate_matrix_add_uint32_t_cpp(left, right));
+    return rcpp_result_gen;
+END_RCPP
+}
+// iterate_matrix_add_float_cpp
+SEXP iterate_matrix_add_float_cpp(SEXP left, SEXP right);
+RcppExport SEXP _BPCells_iterate_matrix_add_float_cpp(SEXP leftSEXP, SEXP rightSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type right(rightSEXP);
+    rcpp_result_gen = Rcpp::wrap(iterate_matrix_add_float_cpp(left, right));
+    return rcpp_result_gen;
+END_RCPP
+}
+// iterate_matrix_add_double_cpp
+SEXP iterate_matrix_add_double_cpp(SEXP left, SEXP right);
+RcppExport SEXP _BPCells_iterate_matrix_add_double_cpp(SEXP leftSEXP, SEXP rightSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type left(leftSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type right(rightSEXP);
+    rcpp_result_gen = Rcpp::wrap(iterate_matrix_add_double_cpp(left, right));
+    return rcpp_result_gen;
+END_RCPP
+}
 // iterate_matrix_mask_uint32_t_cpp
 SEXP iterate_matrix_mask_uint32_t_cpp(SEXP mat, SEXP mask, bool invert);
 RcppExport SEXP _BPCells_iterate_matrix_mask_uint32_t_cpp(SEXP matSEXP, SEXP maskSEXP, SEXP invertSEXP) {
@@ -2732,6 +2768,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_BPCells_iterate_matrix_multiply_uint32_t_cpp", (DL_FUNC) &_BPCells_iterate_matrix_multiply_uint32_t_cpp, 2},
     {"_BPCells_iterate_matrix_multiply_float_cpp", (DL_FUNC) &_BPCells_iterate_matrix_multiply_float_cpp, 2},
     {"_BPCells_iterate_matrix_multiply_double_cpp", (DL_FUNC) &_BPCells_iterate_matrix_multiply_double_cpp, 2},
+    {"_BPCells_iterate_matrix_add_uint32_t_cpp", (DL_FUNC) &_BPCells_iterate_matrix_add_uint32_t_cpp, 2},
+    {"_BPCells_iterate_matrix_add_float_cpp", (DL_FUNC) &_BPCells_iterate_matrix_add_float_cpp, 2},
+    {"_BPCells_iterate_matrix_add_double_cpp", (DL_FUNC) &_BPCells_iterate_matrix_add_double_cpp, 2},
     {"_BPCells_iterate_matrix_mask_uint32_t_cpp", (DL_FUNC) &_BPCells_iterate_matrix_mask_uint32_t_cpp, 3},
     {"_BPCells_iterate_matrix_mask_float_cpp", (DL_FUNC) &_BPCells_iterate_matrix_mask_float_cpp, 3},
     {"_BPCells_iterate_matrix_mask_double_cpp", (DL_FUNC) &_BPCells_iterate_matrix_mask_double_cpp, 3},

--- a/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
+++ b/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
@@ -185,6 +185,18 @@ template <typename T> class MatrixAddition : public MatrixLoader<T> {
         return left.vecMultiplyLeft(v, user_interrupt) +
                right.vecMultiplyLeft(v, user_interrupt);
     }
+    Eigen::MatrixXd denseMultiplyRight(
+        const Eigen::Map<Eigen::MatrixXd> B, std::atomic<bool> *user_interrupt = NULL
+    ) override {
+        return left.denseMultiplyRight(B, user_interrupt) +
+               right.denseMultiplyRight(B, user_interrupt);
+    }
+    Eigen::MatrixXd denseMultiplyLeft(
+        const Eigen::Map<Eigen::MatrixXd> B, std::atomic<bool> *user_interrupt = NULL
+    ) override {
+        return left.denseMultiplyLeft(B, user_interrupt) +
+               right.denseMultiplyLeft(B, user_interrupt);
+    }
     // Linearity of sums (distribution over addition):
     //     rowSums(A+B) = rowSums(A) + rowSums(B) 
     //     colSums(A+B) = colSums(A) + colSums(B) 

--- a/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
+++ b/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
@@ -1,0 +1,153 @@
+// Copyright 2026 BPCells contributors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#pragma once
+
+#include "MatrixIterator.h"
+
+namespace BPCells {
+
+// Element-wise addition of two input matrices with matching dimensions.
+template <typename T> class MatrixAddition : public MatrixLoader<T> {
+  protected:
+    // Running invariants:
+    // - left and right are always about to read the next column for output
+    // - left and right are always positioned at the same column (lockstep)
+    // - row_idx is the next row to resume output from
+    std::unique_ptr<MatrixLoader<T>> left, right;
+    std::vector<T> col_buffer, val_buffer;
+    std::vector<uint32_t> row_buffer;
+    uint32_t row_idx = 0;
+    uint32_t max_load_size, loaded;
+
+    void accumulate_column(MatrixLoader<T> &m) {
+        while (m.load()) {
+            uint32_t cap = m.capacity();
+            const uint32_t *rd = m.rowData();
+            const T *vd = m.valData();
+            for (uint32_t i = 0; i < cap; i++) {
+                col_buffer[rd[i]] += vd[i];
+            }
+        }
+    }
+
+  public:
+    MatrixAddition(std::unique_ptr<MatrixLoader<T>> &&left, std::unique_ptr<MatrixLoader<T>> &&right, uint32_t load_size = 1024)
+        : left(std::move(left))
+        , right(std::move(right))
+        , col_buffer(this->left->rows())
+        , val_buffer(load_size)
+        , row_buffer(load_size)
+        , max_load_size(load_size) {
+
+        if (this->left->rows() != this->right->rows() ||
+            this->left->cols() != this->right->cols())
+            throw std::runtime_error("Matrices have incompatible dimensions for element-wise addition");
+    }
+
+    uint32_t rows() const override { return left->rows(); }
+    uint32_t cols() const override { return left->cols(); }
+
+    const char *rowNames(uint32_t row) override { return left->rowNames(row); }
+    const char *colNames(uint32_t col) override { return left->colNames(col); }
+
+    // Reset the iterators to start from the beginning
+    void restart() override {
+        left->restart();
+        right->restart();
+        row_idx = 0;
+    }
+
+    // Seek to a specific column without reading data
+    // Next call should be to load(). col must be < cols()
+    void seekCol(uint32_t col) override {
+        left->seekCol(col);
+        right->seekCol(col);
+        row_idx = 0;
+    }
+
+    // Advance both matrices to the next column,
+    // return false if there are no more columns,
+    // or error if columns mismatch
+    bool nextCol() override {
+        bool l = left->nextCol();
+        bool r = right->nextCol();
+        if (!l && !r) return false;
+        if (l != r) throw std::runtime_error("MatrixAddition: left and right nextCol() differs. Matrices desynchronized");
+        row_idx = 0;
+        return true;
+    }
+    
+    // Return the index of the current column
+    uint32_t currentCol() const override { return left->currentCol(); }
+
+    // Return false if there are no more entries to load
+    bool load() override {
+        if (row_idx == 0) {
+            // Load the next column of data into col_buffer
+            for (auto &x : col_buffer) {
+                x = 0;
+            }
+
+            // Add each non-zero entry in matrix column to col_buffer
+            accumulate_column(*left);
+            accumulate_column(*right);
+        }
+
+        loaded = 0;
+        for (; row_idx < col_buffer.size() && loaded < max_load_size; row_idx++) {
+            if (col_buffer[row_idx] == 0) continue;
+            val_buffer[loaded] = col_buffer[row_idx];
+            row_buffer[loaded] = row_idx;
+            loaded += 1;
+        }
+        return loaded > 0;
+    }
+
+    // Number of loaded entries available
+    uint32_t capacity() const override { return loaded; }
+
+    // Pointers to the loaded entries
+    uint32_t *rowData() override { return row_buffer.data(); }
+    T *valData() override { return val_buffer.data(); }
+
+    // MATH OPERATIONS: utilize distributive property that (A+B)*v = A*v + B*v
+    Eigen::VectorXd vecMultiplyRight(
+        const Eigen::Map<Eigen::VectorXd> v, std::atomic<bool> *user_interrupt = NULL
+    ) override {
+        return left->vecMultiplyRight(v, user_interrupt) +
+               right->vecMultiplyRight(v, user_interrupt);
+    }
+    Eigen::VectorXd vecMultiplyLeft(
+        const Eigen::Map<Eigen::VectorXd> v, std::atomic<bool> *user_interrupt = NULL
+    ) override {
+        return left->vecMultiplyLeft(v, user_interrupt) +
+               right->vecMultiplyLeft(v, user_interrupt);
+    }
+    // Linearity of sums (distribution over addition):
+    //     rowSums(A+B) = rowSums(A) + rowSums(B) 
+    //     colSums(A+B) = colSums(A) + colSums(B) 
+    std::vector<T> colSums(std::atomic<bool> *user_interrupt = NULL) override {
+        auto l = left->colSums(user_interrupt);
+        auto r = right->colSums(user_interrupt);
+        for (uint32_t i = 0; i < l.size(); i++) {
+            l[i] += r[i];
+        }
+        return l;
+    }
+    std::vector<T> rowSums(std::atomic<bool> *user_interrupt = NULL) override {
+        auto l = left->rowSums(user_interrupt);
+        auto r = right->rowSums(user_interrupt);
+        for (uint32_t i = 0; i < l.size(); i++) {
+            l[i] += r[i];
+        }
+        return l;
+    }
+};
+
+} // end namespace BPCells

--- a/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
+++ b/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
@@ -9,103 +9,159 @@
 #pragma once
 
 #include "MatrixIterator.h"
+#include "OrderRows.h"
 
 namespace BPCells {
 
-// Element-wise addition of two input matrices with matching dimensions.
+// Element-wise addition of two input matrices with matching dimensions via 2-way merge.
 template <typename T> class MatrixAddition : public MatrixLoader<T> {
   protected:
     // Running invariants:
     // - left and right are always about to read the next column for output
     // - left and right are always positioned at the same column (lockstep)
-    // - row_idx is the next row to resume output from
-    std::unique_ptr<MatrixLoader<T>> left, right;
-    std::vector<T> col_buffer, val_buffer;
+    // - [*_idx, *_cap) are the unconsumed left/right buffer ranges
+    // - *_done are true when the column is exhausted
+    // - OrderRows guarantees that row indices are strictly increasing
+    OrderRows<T> left, right;
+    std::vector<T> val_buffer;
     std::vector<uint32_t> row_buffer;
-    uint32_t row_idx = 0;
-    uint32_t max_load_size, loaded;
+    uint32_t loaded = 0;
+    uint32_t max_load_size;
+    uint32_t l_idx = 0, l_cap = 0;
+    uint32_t r_idx = 0, r_cap = 0;
+    bool l_done = true, r_done = true;
 
-    void accumulate_column(MatrixLoader<T> &m) {
-        while (m.load()) {
-            uint32_t cap = m.capacity();
-            const uint32_t *rd = m.rowData();
-            const T *vd = m.valData();
-            for (uint32_t i = 0; i < cap; i++) {
-                col_buffer[rd[i]] += vd[i];
-            }
+    bool refill(OrderRows<T> &side, uint32_t &idx, uint32_t &cap, bool &done) {
+        idx = 0;
+        if (side.load()) {
+            cap = side.capacity();
+            return true;
         }
+        cap = 0;
+        done = true;
+        return false;
     }
 
   public:
     MatrixAddition(std::unique_ptr<MatrixLoader<T>> &&left, std::unique_ptr<MatrixLoader<T>> &&right, uint32_t load_size = 1024)
         : left(std::move(left))
         , right(std::move(right))
-        , col_buffer(this->left->rows())
-        , val_buffer(load_size)
-        , row_buffer(load_size)
         , max_load_size(load_size) {
 
-        if (this->left->rows() != this->right->rows() ||
-            this->left->cols() != this->right->cols())
+        if (this->left.rows() != this->right.rows() ||
+            this->left.cols() != this->right.cols())
             throw std::runtime_error("Matrices have incompatible dimensions for element-wise addition");
+
+        row_buffer.resize(load_size);
+        val_buffer.resize(load_size);
     }
 
-    uint32_t rows() const override { return left->rows(); }
-    uint32_t cols() const override { return left->cols(); }
+    uint32_t rows() const override { return left.rows(); }
+    uint32_t cols() const override { return left.cols(); }
 
-    const char *rowNames(uint32_t row) override { return left->rowNames(row); }
-    const char *colNames(uint32_t col) override { return left->colNames(col); }
+    const char *rowNames(uint32_t row) override { return left.rowNames(row); }
+    const char *colNames(uint32_t col) override { return left.colNames(col); }
 
     // Reset the iterators to start from the beginning
     void restart() override {
-        left->restart();
-        right->restart();
-        row_idx = 0;
+        left.restart();
+        right.restart();
+        loaded = 0;
+        l_idx = l_cap = 0;
+        r_idx = r_cap = 0;
+        l_done = r_done = true; // Stays done till nextCol/seekCol
     }
 
     // Seek to a specific column without reading data
     // Next call should be to load(). col must be < cols()
     void seekCol(uint32_t col) override {
-        left->seekCol(col);
-        right->seekCol(col);
-        row_idx = 0;
+        left.seekCol(col);
+        right.seekCol(col);
+        loaded = 0;
+        l_idx = l_cap = 0;
+        r_idx = r_cap = 0;
+        l_done = r_done = false;
     }
 
     // Advance both matrices to the next column,
     // return false if there are no more columns,
     // or error if columns mismatch
     bool nextCol() override {
-        bool l = left->nextCol();
-        bool r = right->nextCol();
+        bool l = left.nextCol();
+        bool r = right.nextCol();
         if (!l && !r) return false;
         if (l != r) throw std::runtime_error("MatrixAddition: left and right nextCol() differs. Matrices desynchronized");
-        row_idx = 0;
+        loaded = 0;
+        l_idx = l_cap = 0;
+        r_idx = r_cap = 0;
+        l_done = r_done = false;
         return true;
     }
-    
+
     // Return the index of the current column
-    uint32_t currentCol() const override { return left->currentCol(); }
+    uint32_t currentCol() const override { return left.currentCol(); }
 
     // Return false if there are no more entries to load
     bool load() override {
-        if (row_idx == 0) {
-            // Load the next column of data into col_buffer
-            for (auto &x : col_buffer) {
-                x = 0;
-            }
-
-            // Add each non-zero entry in matrix column to col_buffer
-            accumulate_column(*left);
-            accumulate_column(*right);
-        }
-
         loaded = 0;
-        for (; row_idx < col_buffer.size() && loaded < max_load_size; row_idx++) {
-            if (col_buffer[row_idx] == 0) continue;
-            val_buffer[loaded] = col_buffer[row_idx];
-            row_buffer[loaded] = row_idx;
-            loaded += 1;
+
+        // Refill column buffers
+        if (!l_done && l_idx >= l_cap) refill(left, l_idx, l_cap, l_done);
+        if (!r_done && r_idx >= r_cap) refill(right, r_idx, r_cap, r_done);
+
+        while (loaded < max_load_size) {
+            bool l_has = !l_done && l_idx < l_cap;
+            bool r_has = !r_done && r_idx < r_cap;
+            if (!l_has && !r_has) break;
+
+            if (!r_has) {
+                // Drain left in bulk
+                uint32_t take = std::min<uint32_t>(max_load_size - loaded, l_cap - l_idx);
+                const uint32_t *lr = left.rowData();
+                const T *lv = left.valData();
+                std::copy(lr + l_idx, lr + l_idx + take, row_buffer.data() + loaded);
+                std::copy(lv + l_idx, lv + l_idx + take, val_buffer.data() + loaded);
+                l_idx += take;
+                loaded += take;
+                if (l_idx >= l_cap) refill(left, l_idx, l_cap, l_done);
+            } else if (!l_has) {
+                // Drain right in bulk
+                uint32_t take = std::min<uint32_t>(max_load_size - loaded, r_cap - r_idx);
+                const uint32_t *rr = right.rowData();
+                const T *rv = right.valData();
+                std::copy(rr + r_idx, rr + r_idx + take, row_buffer.data() + loaded);
+                std::copy(rv + r_idx, rv + r_idx + take, val_buffer.data() + loaded);
+                r_idx += take;
+                loaded += take;
+                if (r_idx >= r_cap) refill(right, r_idx, r_cap, r_done);
+            } else {
+                uint32_t lr = left.rowData()[l_idx];
+                uint32_t rr = right.rowData()[r_idx];
+                if (lr < rr) {
+                    row_buffer[loaded] = lr;
+                    val_buffer[loaded] = left.valData()[l_idx];
+                    loaded++;
+                    l_idx++;
+                } else if (lr > rr) {
+                    row_buffer[loaded] = rr;
+                    val_buffer[loaded] = right.valData()[r_idx];
+                    loaded++;
+                    r_idx++;
+                } else {
+                    T sum = left.valData()[l_idx] + right.valData()[r_idx];
+                    if (sum != 0) {
+                        row_buffer[loaded] = lr;
+                        val_buffer[loaded] = sum;
+                        loaded++;
+                    }
+                    l_idx++;
+                    r_idx++;
+                }
+                if (!l_done && l_idx >= l_cap) refill(left, l_idx, l_cap, l_done);
+                if (!r_done && r_idx >= r_cap) refill(right, r_idx, r_cap, r_done);
+            }
         }
+
         return loaded > 0;
     }
 
@@ -120,29 +176,29 @@ template <typename T> class MatrixAddition : public MatrixLoader<T> {
     Eigen::VectorXd vecMultiplyRight(
         const Eigen::Map<Eigen::VectorXd> v, std::atomic<bool> *user_interrupt = NULL
     ) override {
-        return left->vecMultiplyRight(v, user_interrupt) +
-               right->vecMultiplyRight(v, user_interrupt);
+        return left.vecMultiplyRight(v, user_interrupt) +
+               right.vecMultiplyRight(v, user_interrupt);
     }
     Eigen::VectorXd vecMultiplyLeft(
         const Eigen::Map<Eigen::VectorXd> v, std::atomic<bool> *user_interrupt = NULL
     ) override {
-        return left->vecMultiplyLeft(v, user_interrupt) +
-               right->vecMultiplyLeft(v, user_interrupt);
+        return left.vecMultiplyLeft(v, user_interrupt) +
+               right.vecMultiplyLeft(v, user_interrupt);
     }
     // Linearity of sums (distribution over addition):
     //     rowSums(A+B) = rowSums(A) + rowSums(B) 
     //     colSums(A+B) = colSums(A) + colSums(B) 
     std::vector<T> colSums(std::atomic<bool> *user_interrupt = NULL) override {
-        auto l = left->colSums(user_interrupt);
-        auto r = right->colSums(user_interrupt);
+        auto l = left.colSums(user_interrupt);
+        auto r = right.colSums(user_interrupt);
         for (uint32_t i = 0; i < l.size(); i++) {
             l[i] += r[i];
         }
         return l;
     }
     std::vector<T> rowSums(std::atomic<bool> *user_interrupt = NULL) override {
-        auto l = left->rowSums(user_interrupt);
-        auto r = right->rowSums(user_interrupt);
+        auto l = left.rowSums(user_interrupt);
+        auto r = right.rowSums(user_interrupt);
         for (uint32_t i = 0; i < l.size(); i++) {
             l[i] += r[i];
         }

--- a/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
+++ b/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
@@ -135,27 +135,27 @@ template <typename T> class MatrixAddition : public MatrixLoader<T> {
                 loaded += take;
                 if (r_idx >= r_cap) refill(right, r_idx, r_cap, r_done);
             } else {
-                uint32_t lr = left.rowData()[l_idx];
-                uint32_t rr = right.rowData()[r_idx];
-                if (lr < rr) {
-                    row_buffer[loaded] = lr;
-                    val_buffer[loaded] = left.valData()[l_idx];
-                    loaded++;
-                    l_idx++;
-                } else if (lr > rr) {
-                    row_buffer[loaded] = rr;
-                    val_buffer[loaded] = right.valData()[r_idx];
-                    loaded++;
-                    r_idx++;
-                } else {
-                    T sum = left.valData()[l_idx] + right.valData()[r_idx];
-                    if (sum != 0) {
-                        row_buffer[loaded] = lr;
-                        val_buffer[loaded] = sum;
-                        loaded++;
-                    }
-                    l_idx++;
-                    r_idx++;
+                const uint32_t *lr = left.rowData();
+                const uint32_t *rr = right.rowData();
+                const T *lv = left.valData();
+                const T *rv = right.valData();
+                while (loaded < max_load_size && l_idx < l_cap && r_idx < r_cap) {
+                    uint32_t lr_v = lr[l_idx];
+                    uint32_t rr_v = rr[r_idx];
+                    T lv_v = lv[l_idx];
+                    T rv_v = rv[r_idx];
+
+                    bool l_pick = lr_v <= rr_v;
+                    bool r_pick = lr_v >= rr_v;
+                    uint32_t out_row = l_pick ? lr_v : rr_v;
+                    T out_val = l_pick ? (r_pick ? lv_v + rv_v : lv_v) : rv_v;
+
+                    bool emit = (lr_v != rr_v) | (out_val != T(0));
+                    row_buffer[loaded] = out_row;
+                    val_buffer[loaded] = out_val;
+                    loaded += emit;
+                    l_idx += l_pick;
+                    r_idx += r_pick;
                 }
                 if (!l_done && l_idx >= l_cap) refill(left, l_idx, l_cap, l_done);
                 if (!r_done && r_idx >= r_cap) refill(right, r_idx, r_cap, r_done);

--- a/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
+++ b/r/src/bpcells-cpp/matrixIterators/MatrixAddition.h
@@ -150,7 +150,7 @@ template <typename T> class MatrixAddition : public MatrixLoader<T> {
                     uint32_t out_row = l_pick ? lr_v : rr_v;
                     T out_val = l_pick ? (r_pick ? lv_v + rv_v : lv_v) : rv_v;
 
-                    bool emit = (lr_v != rr_v) | (out_val != T(0));
+                    bool emit = out_val != T(0);
                     row_buffer[loaded] = out_row;
                     val_buffer[loaded] = out_val;
                     loaded += emit;

--- a/r/src/matrix_utils.cpp
+++ b/r/src/matrix_utils.cpp
@@ -12,6 +12,7 @@
 #include <RcppEigen.h>
 #include "bpcells-cpp/matrixIterators/CSparseMatrix.h"
 #include "bpcells-cpp/matrixIterators/ColwiseRank.h"
+#include "bpcells-cpp/matrixIterators/MatrixAddition.h"
 #include "bpcells-cpp/matrixIterators/ConcatenateMatrix.h"
 #include "bpcells-cpp/matrixIterators/Mask.h"
 #include "bpcells-cpp/matrixIterators/MatrixIndexSelect.h"
@@ -275,6 +276,30 @@ SEXP iterate_matrix_multiply_float_cpp(SEXP left, SEXP right) {
 SEXP iterate_matrix_multiply_double_cpp(SEXP left, SEXP right) {
     return make_unique_xptr<SparseMultiply<double>>(
         take_unique_xptr<MatrixLoader<double>>(left), take_unique_xptr<MatrixLoader<double>>(right)
+    );
+}
+
+// [[Rcpp::export]]
+SEXP iterate_matrix_add_uint32_t_cpp(SEXP left, SEXP right) {
+    return make_unique_xptr<MatrixAddition<uint32_t>>(
+        take_unique_xptr<MatrixLoader<uint32_t>>(left),
+        take_unique_xptr<MatrixLoader<uint32_t>>(right)
+    );
+}
+
+// [[Rcpp::export]]
+SEXP iterate_matrix_add_float_cpp(SEXP left, SEXP right) {
+    return make_unique_xptr<MatrixAddition<float>>(
+        take_unique_xptr<MatrixLoader<float>>(left),
+        take_unique_xptr<MatrixLoader<float>>(right)
+    );
+}
+
+// [[Rcpp::export]]
+SEXP iterate_matrix_add_double_cpp(SEXP left, SEXP right) {
+    return make_unique_xptr<MatrixAddition<double>>(
+        take_unique_xptr<MatrixLoader<double>>(left),
+        take_unique_xptr<MatrixLoader<double>>(right)
     );
 }
 

--- a/r/tests/testthat/test-matrix_transforms.R
+++ b/r/tests/testthat/test-matrix_transforms.R
@@ -397,3 +397,24 @@ test_that("matrix addition works", {
     res_perm <- bp1[perm, ] + bp2[perm, ]
     expect_equal(as(res_perm, "dgCMatrix"), unname((m1 + m2)[perm, ]))
 })
+
+test_that("matrix subtraction works", {
+    set.seed(125124)
+    m1 <- generate_sparse_matrix(20, 10, max_val=1e5)
+    m2 <- generate_sparse_matrix(20, 10, max_val=1e5)
+
+    bp1 <- as(m1, "IterableMatrix")
+    bp2 <- as(m2, "IterableMatrix")
+
+    # Basic subtraction
+    expect_equal(as(bp1 - bp2, "dgCMatrix"), m1 - m2)
+
+    # Zero cancellation: A - A emits no explicit zeros
+    res_self <- as(bp1 - bp1, "dgCMatrix")
+    expect_equal(Matrix::nnzero(res_self), 0)
+    expect_equal(dim(res_self), dim(m1))
+
+    # Transpose: mismatch errors
+    bp1_t <- t(as(t(m1), "IterableMatrix"))
+    expect_error(bp1 - bp1_t)
+})

--- a/r/tests/testthat/test-matrix_transforms.R
+++ b/r/tests/testthat/test-matrix_transforms.R
@@ -347,3 +347,40 @@ test_that("linear regression works", {
     expect_equal(as(m1, "matrix"), ans)
     expect_equal(as(m1t, "matrix"), ans)
 })
+
+test_that("matrix addition works", {
+    set.seed(125124)
+    m1 <- generate_sparse_matrix(20, 10, max_val=1e5)
+    m2 <- generate_sparse_matrix(20, 10, max_val=1e5)
+
+    bp1 <- as(m1, "IterableMatrix")
+    bp2 <- as(m2, "IterableMatrix")
+
+    # Basic addition
+    expect_equal(as(bp1 + bp2, "dgCMatrix"), m1 + m2)
+
+    # Type coercion: mismatched types promote to double
+    bp1_uint <- convert_matrix_type(bp1, "uint32_t")
+    bp2_double <- convert_matrix_type(bp2, "double")
+    res <- bp1_uint + bp2_double
+    expect_identical(matrix_type(res), "double")
+    expect_equal(as(res, "dgCMatrix"), m1 + m2)
+
+    # Transpose: both sides transposed
+    bp1_t <- t(as(t(m1), "IterableMatrix"))
+    bp2_t <- t(as(t(m2), "IterableMatrix"))
+    expect_equal(as(bp1_t + bp2_t, "dgCMatrix"), m1 + m2)
+
+    # Dimnames preserved
+    rownames(m1) <- paste0("row", seq_len(nrow(m1)))
+    colnames(m1) <- paste0("col", seq_len(ncol(m1)))
+    bp1_named <- as(m1, "IterableMatrix")
+    bp2_unnamed <- as(m2, "IterableMatrix")
+    res_named <- bp1_named + bp2_unnamed
+    expect_identical(rownames(res_named), rownames(m1))
+    expect_identical(colnames(res_named), colnames(m1))
+
+    # Dimension mismatch errors
+    m3 <- generate_sparse_matrix(20, 11)
+    expect_error(bp1 + as(m3, "IterableMatrix"))
+})

--- a/r/tests/testthat/test-matrix_transforms.R
+++ b/r/tests/testthat/test-matrix_transforms.R
@@ -8,7 +8,7 @@
 
 generate_sparse_matrix <- function(nrow, ncol, fraction_nonzero = 0.5, max_val = 10) {
   m <- matrix(rbinom(nrow * ncol, 1, fraction_nonzero) * sample.int(max_val, nrow * ncol, replace = TRUE), nrow = nrow)
-  as(m, "dgCMatrix")
+  as(Matrix::Matrix(m, sparse = TRUE), "dgCMatrix")
 }
 
 test_that("Subsetting transform works", {
@@ -383,4 +383,17 @@ test_that("matrix addition works", {
     # Dimension mismatch errors
     m3 <- generate_sparse_matrix(20, 11)
     expect_error(bp1 + as(m3, "IterableMatrix"))
+
+    # Zero cancellation: A + (A * -1) emits no explicit zeros
+    bp1_d <- convert_matrix_type(bp1, "double")
+    neg1 <- bp1_d * -1
+    res_cancel <- bp1_d + neg1
+    mat_cancel <- as(res_cancel, "dgCMatrix")
+    expect_equal(Matrix::nnzero(mat_cancel), 0)
+    expect_equal(dim(mat_cancel), dim(m1))
+
+    # Unsorted inputs: OrderRows sorts
+    perm <- rev(seq_len(nrow(m1)))
+    res_perm <- bp1[perm, ] + bp2[perm, ]
+    expect_equal(as(res_perm, "dgCMatrix"), unname((m1 + m2)[perm, ]))
 })

--- a/r/tests/testthat/test-matrix_utils.R
+++ b/r/tests/testthat/test-matrix_utils.R
@@ -921,7 +921,9 @@ test_that("Generic methods work", {
     rbind_uint32_t = convert_matrix_type(mi, "uint32_t")  %>% {rbind2(.[1:2, ], .[3:nrow(m)])},
     cbind_uint32_t = convert_matrix_type(mi, "uint32_t")  %>% {cbind2(.[, 1:2], .[, 3:ncol(m)])},
     rbind_float = convert_matrix_type(mi, "float")  %>% {rbind2(.[1:2, ], .[3:nrow(m)])},
-    cbind_float = convert_matrix_type(mi, "float")  %>% {cbind2(.[, 1:2], .[, 3:ncol(m)])}
+    cbind_float = convert_matrix_type(mi, "float")  %>% {cbind2(.[, 1:2], .[, 3:ncol(m)])},
+    add = 0.5 * (mi + mi),
+    subtract = (mi * 2) - mi
   )
 
   for (i in names(ident_transforms)) {
@@ -936,7 +938,7 @@ test_that("Generic methods work", {
     expect_identical(rowSums(trans), rowSums(m))
     expect_identical(colSums(trans), colSums(m))
 
-    if (i %in% c("shift_scale_1", "shift_scale_2")) {
+    if (i %in% c("shift_scale_1", "shift_scale_2", "add", "subtract")) {
       expect_identical(as.matrix(as(trans, "dgCMatrix")), as.matrix(m))
     } else {
       expect_identical(as(trans, "dgCMatrix"), m)

--- a/r/tests/testthat/test-matrix_utils.R
+++ b/r/tests/testthat/test-matrix_utils.R
@@ -938,7 +938,7 @@ test_that("Generic methods work", {
     expect_identical(rowSums(trans), rowSums(m))
     expect_identical(colSums(trans), colSums(m))
 
-    if (i %in% c("shift_scale_1", "shift_scale_2", "add", "subtract")) {
+    if (i %in% c("shift_scale_1", "shift_scale_2")) {
       expect_identical(as.matrix(as(trans, "dgCMatrix")), as.matrix(m))
     } else {
       expect_identical(as(trans, "dgCMatrix"), m)


### PR DESCRIPTION
Hi @bnprks, here are the matrix addition changes we discussed.
Resolves outstanding to-do in NEWS.md and Issue #296.

### Description
Prior to this change, combining two matrices required intermediate materialization in memory with `dgCMatrix`, resulting in high memory overhead for very large matrices. This pull request adds a lazy element-wise addition of two `IterableMatrix` objects through the existing `+` operator.
- Adds a `MatrixAddition` class that iterates column-by-column and sums via a dense accumulator mirroring `SparseMultiply`.
- Overrides `colSums`/`rowSums`/`vecMultiplyRight`/`vecMultiplyLeft` via distributive/linearity properties to bypass accumulation
- Follows `MatrixMultiply` subsetting and `rbind2`/`cbind2` `merge_dimnames()` conventions.

### Behavior
- Matrix size requirements for element-wise addition are enforced (identical dimensions)
- Type coercion: mismatched matrix types promote to `double`, equal types preserved.
- Transpose: both matrices must share internal transpose states (users are pointed to `transpose_storage_order()`)

### Tests
- Added one `MatrixMath.Add` test to align with existing arithmetic-loader conventions
- Added basic addition, type coercion, transpose, dimnames, and dim-mismatch tests

### Scope
- Element-wise subtraction is not in this PR. Users can still subtract explicitly via `mat1 + (mat2 * -1)`. To discuss if subtraction should be implemented as a separate function.