### PR TITLE
[r] Support graph list inputs in clustering

### DIFF
--- a/r/R/clustering.R
+++ b/r/R/clustering.R
@@ -234,13 +234,13 @@ knn_to_geodesic_graph <- function(knn, return_type = c("matrix", "list"), thread
   return(res)
 }
 
-#' Cluster an adjacency matrix
+#' Cluster an adjacency matrix or graph edge list
 #' @rdname cluster_graph
 #' @details **cluster_graph_leiden**: Leiden clustering algorithm `igraph::cluster_leiden()`. 
 #'    Note that when using `objective_function = "CPM"` the number of clusters empirically scales with `cells * resolution`,
 #'    so 1e-3 is a good resolution for 10k cells, but 1M cells is better with a 1e-5 resolution. A resolution of 1 is a 
 #'    good default when `objective_function = "modularity"` per the default.
-#' @param mat Symmetric adjacency matrix (dgCMatrix) output from e.g. `knn_to_snn_graph()` or `knn_to_geodesic_graph()`. Only the lower triangle is used.
+#' @param mat Symmetric adjacency matrix (dgCMatrix) or graph list output from e.g. `knn_to_snn_graph()` or `knn_to_geodesic_graph()`. Only the lower triangle is used for matrix inputs.
 #' @param resolution Resolution parameter. Higher values result in more clusters
 #' @param objective_function Graph statistic to optimize during clustering. Modularity is the default as it keeps resolution independent of dataset size (see details below). 
 #'    For the meaning of each option, see `igraph::cluster_leiden()`.
@@ -261,7 +261,7 @@ cluster_graph_leiden <- function(
 
   objective_function <- match.arg(objective_function)
 
-  igraph::graph_from_adjacency_matrix(mat, weighted = TRUE, diag = FALSE, mode = "lower") %>%
+  graph_from_clustering_input(mat) %>%
     igraph::cluster_leiden(resolution_parameter = resolution, objective_function=objective_function, ...) %>%
     igraph::membership() %>%
     as.factor()
@@ -282,10 +282,24 @@ cluster_graph_louvain <- function(
   on.exit(restore_seed(prev_seed), add = TRUE)
   set.seed(seed)
 
-  igraph::graph_from_adjacency_matrix(mat, weighted = TRUE, diag = FALSE, mode = "lower") %>%
+  graph_from_clustering_input(mat) %>%
     igraph::cluster_louvain(resolution = resolution) %>%
     igraph::membership() %>%
     as.factor()
+}
+
+graph_from_clustering_input <- function(mat) {
+  if (is.list(mat) && all(c("i", "j", "weight", "dim") %in% names(mat))) {
+    graph <- igraph::make_empty_graph(n = mat$dim, directed = FALSE)
+    keepers <- mat$i != mat$j
+    if (!any(keepers)) return(graph)
+    return(igraph::add_edges(
+      graph,
+      as.vector(rbind(mat$i[keepers] + 1L, mat$j[keepers] + 1L)),
+      attr = list(weight = mat$weight[keepers])
+    ))
+  }
+  igraph::graph_from_adjacency_matrix(mat, weighted = TRUE, diag = FALSE, mode = "lower")
 }
 
 #' @rdname cluster_graph

--- a/r/man/cluster_graph.Rd
+++ b/r/man/cluster_graph.Rd
@@ -4,7 +4,7 @@
 \alias{cluster_graph_leiden}
 \alias{cluster_graph_louvain}
 \alias{cluster_graph_seurat}
-\title{Cluster an adjacency matrix}
+\title{Cluster an adjacency matrix or graph edge list}
 \usage{
 cluster_graph_leiden(
   mat,
@@ -19,7 +19,7 @@ cluster_graph_louvain(mat, resolution = 1, seed = 12531)
 cluster_graph_seurat(mat, resolution = 0.8, ...)
 }
 \arguments{
-\item{mat}{Symmetric adjacency matrix (dgCMatrix) output from e.g. \code{knn_to_snn_graph()} or \code{knn_to_geodesic_graph()}. Only the lower triangle is used.}
+\item{mat}{Symmetric adjacency matrix (dgCMatrix) or graph list output from e.g. \code{knn_to_snn_graph()} or \code{knn_to_geodesic_graph()}. Only the lower triangle is used for matrix inputs.}
 
 \item{resolution}{Resolution parameter. Higher values result in more clusters}
 
@@ -34,7 +34,7 @@ For the meaning of each option, see \code{igraph::cluster_leiden()}.}
 Factor vector containing the cluster assignment for each cell.
 }
 \description{
-Cluster an adjacency matrix
+Cluster an adjacency matrix or graph edge list
 }
 \details{
 \strong{cluster_graph_leiden}: Leiden clustering algorithm \code{igraph::cluster_leiden()}.

--- a/r/tests/testthat/test-clustering.R
+++ b/r/tests/testthat/test-clustering.R
@@ -59,6 +59,7 @@ test_that("igraph clustering doesn't crash", {
     test_data <- readRDS("../data/iris_geodesic_graph.rds")
     knn <- test_data$knn
     graph <- knn_to_geodesic_graph(knn)
+    graph_list <- knn_to_geodesic_graph(knn, return_type="list")
 
     # The `resolution_parameter` param in igraph `cluster_leiden()` is deprecated,
     # causing `expect_no_condition()` to fail. This workaround avoids test failures from 
@@ -70,8 +71,14 @@ test_that("igraph clustering doesn't crash", {
         expect_no_error(cluster_graph_leiden(graph))
         expect_no_error(cluster_graph_leiden(graph, objective_function="CPM"))
     })
+    expect_identical(
+        suppressWarnings(cluster_graph_leiden(graph)),
+        suppressWarnings(cluster_graph_leiden(graph_list))
+    )
 
     expect_no_condition(cluster_graph_louvain(graph))
+    expect_no_condition(cluster_graph_louvain(graph_list))
+    expect_identical(cluster_graph_louvain(graph), cluster_graph_louvain(graph_list))
 })
 
 test_that("knn_hnsw rownames come from query", {


### PR DESCRIPTION
## Context
I ran into a large transient memory spike when clustering a shared-nearest-neighbor graph built from about 463k cells and 20 embedding dimensions. The KNN search completed, but memory climbed sharply during graph clustering. Smaller benchmarks pointed to the `igraph::graph_from_adjacency_matrix()` conversion inside the current clustering path as the expensive step, rather than KNN search, SNN construction, or the final membership vector.

Representative peak RSS measurements from the same graph construction/clustering path were:

| Input / stage | Peak RSS |
|---|---:|
| 20k cells, KNN only | ~0.59-0.66 GiB |
| 20k cells, KNN + SNN | ~0.68-0.70 GiB |
| 20k cells, KNN + SNN + Leiden through sparse matrix | ~5.98-6.00 GiB |
| 30k cells, sparse-matrix clustering route | ~12.58 GiB |
| 30k cells, direct edge-list route | ~0.87 GiB |
| 50k cells, sparse-matrix clustering route | ~42.9 GiB |
| 50k cells, direct edge-list route | ~1.04 GiB |

A separate 20k-cell equivalence check produced identical Leiden memberships between the sparse matrix route and the direct edge-list route. This PR upstreams that lower-memory route for BPCells graph-list outputs while leaving the existing sparse matrix behavior unchanged.

## Summary
- Allow `cluster_graph_leiden()` and `cluster_graph_louvain()` to accept graph-list outputs from `knn_to_snn_graph(return_type = "list")` and `knn_to_geodesic_graph(return_type = "list")`.
- Build igraph objects directly from the edge list for list inputs, while keeping the existing sparse matrix path unchanged.
- Convert BPCells 0-based edge-list indices to igraph 1-based vertex IDs internally.
- Ignore self-loops for list inputs to match the existing `diag = FALSE` matrix behavior.
- Add regression coverage that matrix and graph-list inputs produce identical Leiden and Louvain memberships on the same graph.

## Testing

```r
testthat::test_file("tests/testthat/test-clustering.R")
```

Result: 13 passed; 2 skipped because optional packages `RcppAnnoy` and `RcppHNSW` were not installed in the test environment.

The new regression assertions are in the existing `igraph clustering doesn't crash` test and did run. The two skipped tests are separate optional ANN tests guarded by `skip_if_not_installed("RcppAnnoy")` and `skip_if_not_installed("RcppHNSW")`; I did not install those optional packages for this focused test run.

## Disclosure
GPT-5.5 was utilized to help draft this PR and implementation.
