### PR TITLE
[r] Fix iterative peak merging for isolated peaks

### DIFF
--- a/r/R/atac_utils.R
+++ b/r/R/atac_utils.R
@@ -301,6 +301,7 @@ merge_peaks_iterative <- function(peaks) {
   overlaps <- range_overlaps(peaks, peaks) %>%
     dplyr::filter(from < to)
 
+  # Track peak indices which are neither conclusively excluded or included from a keeper set
   remaining <- seq_len(nrow(peaks))
   keeper_sets <- list()
   while (length(remaining) > 0) {

--- a/r/R/atac_utils.R
+++ b/r/R/atac_utils.R
@@ -304,10 +304,6 @@ merge_peaks_iterative <- function(peaks) {
   remaining <- seq_len(nrow(peaks))
   keeper_sets <- list()
   while (length(remaining) > 0) {
-    if (nrow(overlaps) == 0) {
-      keeper_sets <- c(keeper_sets, list(remaining))
-      break
-    }
 
     # Add peaks with no higher-ranked overlap to the keeper set. This includes
     # peaks that are isolated from the start or become isolated after discards.

--- a/r/R/atac_utils.R
+++ b/r/R/atac_utils.R
@@ -296,25 +296,33 @@ merge_peaks_iterative <- function(peaks) {
   peaks <- tibble::as_tibble(peaks) %>%
     dplyr::distinct(chr, start, end, .keep_all = TRUE)
 
-  overlaps <- range_overlaps(peaks, peaks)
-  # Initialize keeper set with any non-overlapping peaks
-  keeper_sets <- list(setdiff(seq_len(nrow(peaks)), overlaps$from))
+  # Only keep one direction for each overlap. With peaks ordered by priority,
+  # lower row numbers have higher priority.
+  overlaps <- range_overlaps(peaks, peaks) %>%
+    dplyr::filter(from < to)
 
-  # Maintain invariant: overlaps contains only overlap pairs where we have not
-  #    permanently kept or discarded either of the elements in the pair
-  overlaps <- dplyr::filter(overlaps, from < to)
-  while (nrow(overlaps) > 0) {
-    # Add peaks with no higher-ranked overlap to the keeper set
-    keeper_set <- setdiff(overlaps$from, overlaps$to)
+  remaining <- seq_len(nrow(peaks))
+  keeper_sets <- list()
+  while (length(remaining) > 0) {
+    if (nrow(overlaps) == 0) {
+      keeper_sets <- c(keeper_sets, list(remaining))
+      break
+    }
+
+    # Add peaks with no higher-ranked overlap to the keeper set. This includes
+    # peaks that are isolated from the start or become isolated after discards.
+    keeper_set <- setdiff(remaining, overlaps$to)
     keeper_sets <- c(keeper_sets, list(keeper_set))
+
     # Mark peaks that overlap directly with the keeper set
-    discard_set <- overlaps$to[overlaps$from %in% keeper_set] %>% unique()
+    discard_set <- overlaps$to[overlaps$from %in% keeper_set] %>%
+      unique()
+    remove_set <- c(keeper_set, discard_set)
+    remaining <- setdiff(remaining, remove_set)
+
     # Discard all overlap information on the keeper and discard sets
     overlaps <- overlaps %>%
-      dplyr::filter(
-        !(to %in% discard_set), !(from %in% discard_set),
-        !(from %in% keeper_set)
-      )
+      dplyr::filter(!(from %in% remove_set), !(to %in% remove_set))
   }
   return(peaks[sort(unlist(keeper_sets)), ])
 }

--- a/r/tests/testthat/test-atac_utils.R
+++ b/r/tests/testthat/test-atac_utils.R
@@ -84,6 +84,13 @@ test_that("tile_ranges works", {
 })
 
 test_that("merge_peaks works", {
+  peaks0 <- tibble::tibble(
+    chr = "chr1",
+    start = as.integer(c(1, 5)),
+    end = start + 2L
+  )
+  expect_identical(merge_peaks_iterative(peaks0), peaks0)
+
   peaks1 <- tibble::tibble(
     chr = "chr1",
     start = as.integer(1:10),
@@ -95,6 +102,18 @@ test_that("merge_peaks works", {
     end = start + 2L
   )
   expect_identical(merge_peaks_iterative(peaks1), res1)
+
+  peaks1_chain <- tibble::tibble(
+    chr = "chr1",
+    start = as.integer(1:3),
+    end = start + 2L
+  )
+  res1_chain <- tibble::tibble(
+    chr = "chr1",
+    start = as.integer(c(1, 3)),
+    end = start + 2L
+  )
+  expect_identical(merge_peaks_iterative(peaks1_chain), res1_chain)
 
   peaks2 <- tibble::tibble(
     chr = "chr1",


### PR DESCRIPTION
## Context

This PR fixes an edge case in `merge_peaks_iterative()` where the implementation could return too few peaks compared with the ArchR-style iterative overlap procedure it documents. The previous implementation used `range_overlaps(peaks, peaks)` to initialize keepers, but that overlap table includes self-overlaps. As a result, peaks with no real overlaps were not included in the initial keeper set. The loop also stopped once no overlap edges remained, so peaks that became isolated after a higher-priority neighboring peak discarded their only overlap were dropped instead of being retained on the next iteration.

A minimal example is a three-peak chain ordered by priority:

```r
tibble::tibble(
  chr = "chr1",
  start = as.integer(1:3),
  end = start + 2L
)
```

With half-open ranges, peak 1 overlaps peak 2, peak 2 overlaps peak 3, and peak 1 does not overlap peak 3. The iterative ArchR-style result should keep peaks 1 and 3. The previous BPCells implementation kept only peak 1 because peak 3 became isolated after peak 2 was discarded and the loop then terminated. Fully non-overlapping peak sets were also dropped.

## Changes

- Track the remaining candidate peaks explicitly during iterative merging.
- Keep all remaining peaks when no overlap edges remain.
- Preserve the existing behavior that lower input row numbers have higher priority and output rows are returned in input order.
- Add regression tests for already isolated peaks and peaks that become isolated after an iterative discard.

## Testing

Focused ATAC utility tests:

```r
testthat::test_file("tests/testthat/test-atac_utils.R")
```

Result: 67 passed, 1 skipped (`macs2` not installed).

Full test suite:

```r
testthat::test_dir("tests/testthat")
```

Result: 1984 passed, 19 skipped, 2 failed.

The failures were existing HDF5 gzip write tests outside this change:

- `test-fragment_io.R:107`: failed creating dataset `cell_names`.
- `test-matrix_io.R:168`: failed creating dataset `col_names`.

## Disclosure

GPT-5.5 was utilized to help investigate the issue and draft this PR.
